### PR TITLE
Feature/logout

### DIFF
--- a/src/main/java/shootingstar/var/Service/UserAuthService.java
+++ b/src/main/java/shootingstar/var/Service/UserAuthService.java
@@ -10,12 +10,15 @@ import shootingstar.var.entity.User;
 import shootingstar.var.exception.CustomException;
 import shootingstar.var.jwt.JwtTokenProvider;
 import shootingstar.var.repository.UserRepository;
+import shootingstar.var.util.LoginListRedisUtil;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static shootingstar.var.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+import static shootingstar.var.exception.ErrorCode.LOGGED_IN_SOMEWHERE_ELSE;
 
 @Service
 @RequiredArgsConstructor
@@ -23,14 +26,22 @@ public class UserAuthService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider tokenProvider;
+    private final LoginListRedisUtil loginListRedisUtil;
 
     public String refreshAccessToken(String refreshToken) {
-        if (refreshToken == null) {
-            throw new CustomException(INVALID_REFRESH_TOKEN);
-        }
-        tokenProvider.validateRefreshToken(refreshToken);
-        tokenProvider.checkRefreshTokenState(refreshToken);
+        tokenProvider.validateRefreshToken(refreshToken); // 토큰 위변조 체크
         Authentication authentication = tokenProvider.getAuthenticationFromRefreshToken(refreshToken);
+
+        String userUUID = authentication.getName();
+        String storeRefreshToken = loginListRedisUtil.getData(userUUID);
+        // 현재 로그인 리스트에 등록된 토큰과 다를 경우
+        // 현재 로그인 리스트에 등록되진 않았지만 리프레시 토큰을 들고 있는 경우는 다른 곳에서 로그인한 뒤 그곳에서 로그아웃을 한 경우이다.
+        // 위 두 경우 모두 다른 곳에서 로그인 되었다는 뜻이기에 에러를 반환
+        if (!Objects.equals(storeRefreshToken, refreshToken)) {
+            throw new CustomException(LOGGED_IN_SOMEWHERE_ELSE);
+        }
+
+        tokenProvider.checkRefreshTokenState(refreshToken);
 
         return tokenProvider.generateAccessToken(authentication, Instant.now());
     }
@@ -50,5 +61,21 @@ public class UserAuthService {
 
         // 존재하지 않는 사용자인 경우 다른 로직을 처리할 수 있도록 null 반환
         return null;
+    }
+
+    public void logout(String refreshToken) {
+        tokenProvider.validateRefreshToken(refreshToken);
+
+        Authentication authentication = tokenProvider.getAuthenticationFromRefreshToken(refreshToken);
+
+        String userUUID = authentication.getName();
+
+        tokenProvider.expiredRefreshTokenAtRedis(refreshToken); // 현재 토큰을 만료 처리한다
+
+        String storeRefreshToken = loginListRedisUtil.getData(userUUID); // 로그인 리스트에 등록된 토큰
+        if (!Objects.equals(storeRefreshToken, refreshToken)) { // 로그인 리스트와 현재 등록된 토큰이 다를 경우
+            tokenProvider.expiredRefreshTokenAtRedis(storeRefreshToken); // 로그인 리스트에 등록된 토큰도 만료 시킨다.
+        }
+        loginListRedisUtil.deleteData(userUUID); // 로그인 리스트에서 사용자 정보를 제거한다.
     }
 }

--- a/src/main/java/shootingstar/var/config/RedisConfig.java
+++ b/src/main/java/shootingstar/var/config/RedisConfig.java
@@ -19,6 +19,8 @@ public class RedisConfig {
     private int redisPort1; // jwt 레디스 포트
     @Value("${spring.data.redis.port2}")
     private int redisPort2; // mail 레디스 포트
+    @Value("${spring.data.redis.port3}")
+    private int redisPort3; // loginList 레디스 포트
     @Value("${spring.data.redis.password}")
     private String redisPassword;
 
@@ -35,10 +37,20 @@ public class RedisConfig {
 
     // mail 레디스 빈 등록
     @Bean
-    public RedisConnectionFactory mailRedisConnectionFactoryTwo() {
+    public RedisConnectionFactory mailRedisConnectionFactory() {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
         redisConfiguration.setHostName(redisHost);
         redisConfiguration.setPort(redisPort2);
+        redisConfiguration.setPassword(redisPassword);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    // 로그인 리스트 레디스 빈 등록
+    @Bean
+    public RedisConnectionFactory loginListRedisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(redisHost);
+        redisConfiguration.setPort(redisPort3);
         redisConfiguration.setPassword(redisPassword);
         return new LettuceConnectionFactory(redisConfiguration);
     }
@@ -57,7 +69,17 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<?, ?> mailRedisTemplate() {
         RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(mailRedisConnectionFactoryTwo());   //connection
+        redisTemplate.setConnectionFactory(mailRedisConnectionFactory());   //connection
+        redisTemplate.setKeySerializer(new StringRedisSerializer());    // key
+        redisTemplate.setValueSerializer(new StringRedisSerializer());  // value
+        return redisTemplate;
+    }
+
+    // 로그인 리스트 레디스 템플릿 등록
+    @Bean
+    public RedisTemplate<?, ?> loginListRedisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(loginListRedisConnectionFactory());   //connection
         redisTemplate.setKeySerializer(new StringRedisSerializer());    // key
         redisTemplate.setValueSerializer(new StringRedisSerializer());  // value
         return redisTemplate;

--- a/src/main/java/shootingstar/var/controller/AllUserController.java
+++ b/src/main/java/shootingstar/var/controller/AllUserController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -66,7 +67,7 @@ public class AllUserController {
                     @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @GetMapping("/duplicate/nickname/{nickname}")
-    public ResponseEntity<Boolean> checkNicknameDuplicate(@NotBlank @PathVariable String nickname){
+    public ResponseEntity<Boolean> checkNicknameDuplicate(@NotEmpty @PathVariable("nickname") String nickname){
         return ResponseEntity.ok(duplicateService.checkNicknameDuplicate(nickname));
     }
 
@@ -78,7 +79,7 @@ public class AllUserController {
                     @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @GetMapping("/duplicate/email/{email}")
-    public ResponseEntity<Boolean> checkEmailDuplicate(@NotBlank @PathVariable String email){
+    public ResponseEntity<Boolean> checkEmailDuplicate(@NotBlank @PathVariable("email") String email){
         return ResponseEntity.ok(duplicateService.checkEmailDuplicate(email));
     }
 

--- a/src/main/java/shootingstar/var/controller/UserAuthController.java
+++ b/src/main/java/shootingstar/var/controller/UserAuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +17,8 @@ import shootingstar.var.Service.UserAuthService;
 import shootingstar.var.dto.req.AccessKakaoReqDto;
 import shootingstar.var.dto.res.AccessKakaoResDto;
 import shootingstar.var.dto.res.KakaoUserResDto;
+import shootingstar.var.exception.CustomException;
+import shootingstar.var.exception.ErrorCode;
 import shootingstar.var.exception.ErrorResponse;
 import shootingstar.var.jwt.JwtTokenProvider;
 import shootingstar.var.jwt.TokenInfo;
@@ -24,8 +27,11 @@ import shootingstar.var.oAuth.KakaoAPI;
 import shootingstar.var.oAuth.KakaoUserInfo;
 import shootingstar.var.util.TokenUtil;
 
+import static shootingstar.var.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+
 @Tag(name = "인증 컨트롤러", description = "사용자 인증 관련 컨트롤러")
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class UserAuthController {
@@ -68,10 +74,6 @@ public class UserAuthController {
 
             return ResponseEntity.ok().body(new AccessKakaoResDto("JOIN", kakaoUserResDto));
         } else {
-            String oldRefreshToken = TokenUtil.getTokenFromCookie(request);
-
-            if (oldRefreshToken != null) tokenProvider.expiredRefreshToken(oldRefreshToken);
-
             TokenInfo tokenInfo = tokenProvider.generateToken(authentication);
             String refreshToken = tokenInfo.getRefreshToken();
 
@@ -82,22 +84,24 @@ public class UserAuthController {
         }
     }
 
-
     @Operation(summary = "로그아웃 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
-                    description = "로그아웃에 성공하였을 때, 쿠키에서 토큰을 삭제해서 반환",
+                    description = "로그아웃에 성공하였을 때, 에러가 발생하여도 내부적으로 로그만 남기고 쿠키에서 토큰을 삭제해서 반환",
                     content = {@Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))}),
-            @ApiResponse(responseCode = "500",
-                    description = "Redis JSON 파싱 에러",
-                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @DeleteMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = TokenUtil.getTokenFromCookie(request);
-        tokenProvider.expiredRefreshToken(refreshToken);
 
-        TokenUtil.updateCookie(response, refreshToken, 0);
+        try {
+            authService.logout(refreshToken);
+        } catch (Exception e) { // 리프레시 토큰 검증 과정에서 에러가 발생하더라도 로그만 남기고 로그아웃 처리
+            log.error("Logout process failed: {}", e.getMessage());
+        } finally {
+            // 로그아웃 요청에 대해 클라이언트의 리프레시 토큰 쿠키를 삭제
+            TokenUtil.updateCookie(response, null, 0);
+        }
 
         return ResponseEntity.ok().body("성공적으로 로그아웃 되었습니다.");
     }
@@ -111,7 +115,8 @@ public class UserAuthController {
                                      "- 잘못된 RefreshToken : 0106\n" +
                                     "- 만료된 RefreshToken : 0107\n" +
                                     "- 지원하지 않는 RefreshToken : 0108\n" +
-                                    "- Claim이 빈 Refresh Token : 0109",
+                                    "- Claim이 빈 Refresh Token : 0109\n" +
+                                    "- 다른 장소에서 로그인 됨 : 0114",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "500",
             description = "Redis JSON 파싱 에러",
@@ -120,11 +125,17 @@ public class UserAuthController {
     @PostMapping("/refresh")
     public ResponseEntity<String> refresh(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = TokenUtil.getTokenFromCookie(request);
-
-        String newAccessToken = authService.refreshAccessToken(refreshToken);
-
-        TokenUtil.addHeader(response, newAccessToken);
-
-        return ResponseEntity.ok().body("성공적으로 액세스 토큰이 재발행 되었습니다.");
+        
+        String newAccessToken;
+        try {
+            newAccessToken = authService.refreshAccessToken(refreshToken);
+            TokenUtil.addHeader(response, newAccessToken);
+            return ResponseEntity.ok().body("성공적으로 액세스 토큰이 재발행 되었습니다.");
+        } catch (CustomException e) {
+            ErrorCode errorCode = e.getErrorCode();
+            // 클라이언트의 리프레시 토큰 쿠키를 삭제
+            TokenUtil.updateCookie(response, null, 0);
+            throw new CustomException(errorCode);
+        }
     }
 }

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -17,16 +17,18 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(FORBIDDEN, "0102", "잘못된 Access Token 입니다."),
     EXPIRED_ACCESS_TOKEN(FORBIDDEN, "0103", "만료된 Access Token 입니다."),
     UNSUPPORTED_ACCESS_TOKEN(FORBIDDEN, "0104", "지원하지 않는 Access Token 입니다."),
-    ILLEGAL_ACCESS_TOKEN(FORBIDDEN, "0105", "Claim이 빈 Access Token 입니다."),
+    ILLEGAL_ACCESS_TOKEN(FORBIDDEN, "0105", "권한 정보가 없는 Access Token 입니다."),
     INVALID_REFRESH_TOKEN(FORBIDDEN, "0106", "잘못된 Refresh Token 입니다."),
     EXPIRED_REFRESH_TOKEN(FORBIDDEN, "0107", "만료된 Refresh Token 입니다."),
     UNSUPPORTED_REFRESH_TOKEN(FORBIDDEN, "0108", "지원하지 않는 Refresh Token 입니다."),
-    ILLEGAL_REFRESH_TOKEN(FORBIDDEN, "0109", "Claim이 빈 Refresh Token 입니다."),
+    ILLEGAL_REFRESH_TOKEN(FORBIDDEN, "0109", "권한 정보가 없는 Refresh Token 입니다."),
 
     KAKAO_AUTHENTICATION_ERROR(UNAUTHORIZED, "0110", "카카오로부터 ACCESS 토큰 획득에 실패했습니다."),
     KAKAO_CONNECT_FAILED_TOKEN_ENDPOINT(UNAUTHORIZED, "0111", "카카오 토큰 엔드포인트와 통신에 실패하였습니다."),
     KAKAO_FAILED_GET_USERINFO_ERROR(UNAUTHORIZED, "0112", "카카오로부터 사용자 정보를 가져오지 못했습니다."),
     KAKAO_CONNECT_FAILED_USERINFO_ENDPOINT(UNAUTHORIZED, "0113", "카카오 사용자 정보 엔드포인트와 통신에 실패하였습니다."),
+
+    LOGGED_IN_SOMEWHERE_ELSE(FORBIDDEN, "0114", "다른 장소에서 로그인 되었습니다."),
 
     NOT_FOUND_END_POINT(NOT_FOUND, "0200", "존재하지 않는 접근입니다."),
 

--- a/src/main/java/shootingstar/var/jwt/JwtTokenProvider.java
+++ b/src/main/java/shootingstar/var/jwt/JwtTokenProvider.java
@@ -21,6 +21,7 @@ import shootingstar.var.exception.CustomException;
 import shootingstar.var.exception.ErrorCode;
 import shootingstar.var.repository.UserRepository;
 import shootingstar.var.util.JwtRedisUtil;
+import shootingstar.var.util.LoginListRedisUtil;
 import shootingstar.var.util.TokenUtil;
 
 import java.security.Key;
@@ -41,6 +42,7 @@ public class JwtTokenProvider {
     private final Key refreshKey;
     private final TokenProperty tokenProperty;
     private final JwtRedisUtil jwtRedisUtil;
+    private final LoginListRedisUtil loginListRedisUtil;
     private final UserRepository userRepository;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -48,9 +50,10 @@ public class JwtTokenProvider {
 
     public JwtTokenProvider(@Value("${jwt.secret-access}") String accessSecretKey,
                             @Value("${jwt.secret-refresh}") String refreshSecretKey,
-                            TokenProperty tokenProperty, UserRepository userRepository, JwtRedisUtil jwtRedisUtil) {
+                            TokenProperty tokenProperty, UserRepository userRepository, JwtRedisUtil jwtRedisUtil, LoginListRedisUtil loginListRedisUtil) {
         this.tokenProperty = tokenProperty;
         this.jwtRedisUtil = jwtRedisUtil;
+        this.loginListRedisUtil = loginListRedisUtil;
         this.userRepository = userRepository;
         byte[] accessKeyBytes = Decoders.BASE64.decode(accessSecretKey);
         byte[] refreshKeyBytes = Decoders.BASE64.decode(refreshSecretKey);
@@ -93,6 +96,19 @@ public class JwtTokenProvider {
     }
 
     // 리프레시 토큰 생성 메서드
+//    public String generateRefreshToken(Authentication authentication, Instant now, Instant refreshTokenExpiresIn) {
+//        String refreshToken = Jwts.builder()
+//                .setSubject(authentication.getName())
+//                .setIssuedAt(Date.from(now))
+//                .setExpiration(Date.from(refreshTokenExpiresIn))
+//                .signWith(refreshKey, SignatureAlgorithm.HS256)
+//                .compact();
+//
+//        saveRefreshTokenAtRedis(refreshToken, refreshTokenExpiresIn);
+//
+//        return refreshToken;
+//    }
+
     public String generateRefreshToken(Authentication authentication, Instant now, Instant refreshTokenExpiresIn) {
         String refreshToken = Jwts.builder()
                 .setSubject(authentication.getName())
@@ -101,7 +117,14 @@ public class JwtTokenProvider {
                 .signWith(refreshKey, SignatureAlgorithm.HS256)
                 .compact();
 
+        String beforeRefreshToken = loginListRedisUtil.getData(authentication.getName());
+
+        if (beforeRefreshToken != null) {
+            expiredRefreshTokenAtRedis(beforeRefreshToken);
+        }
+
         saveRefreshTokenAtRedis(refreshToken, refreshTokenExpiresIn);
+        saveLoginListWithRefreshTokenAtRedis(authentication.getName(), refreshToken, refreshTokenExpiresIn);
 
         return refreshToken;
     }
@@ -140,8 +163,8 @@ public class JwtTokenProvider {
     }
 
     // refresh 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
-    public Authentication getAuthenticationFromRefreshToken(String token) {
-        Claims claims = parseClaims(token, refreshKey);
+    public Authentication getAuthenticationFromRefreshToken(String refreshToken) {
+        Claims claims = parseClaims(refreshToken, refreshKey);
 
         if (claims.getSubject() == null) {
             log.info("토큰에서 사용자 식별 정보를 찾을 수 없습니다.");
@@ -163,6 +186,11 @@ public class JwtTokenProvider {
 
     // access 토큰 정보를 검증하는 메서드
     public boolean validateToken(String token) {
+        if (token == null) {
+            log.info("Not Found ACCESS token");
+            throw new CustomException(INVALID_ACCESS_TOKEN);
+        }
+
         try {
             Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(token);
             return true;
@@ -183,6 +211,11 @@ public class JwtTokenProvider {
 
     // refresh 토큰 정보를 검증하는 메서드
     public void validateRefreshToken(String token) {
+        if (token == null) {
+            log.info("Not Found REFRESH token");
+            throw new CustomException(INVALID_REFRESH_TOKEN);
+        }
+
         try {
             Jwts.parserBuilder().setSigningKey(refreshKey).build().parseClaimsJws(token);
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
@@ -214,7 +247,7 @@ public class JwtTokenProvider {
         jwtRedisUtil.setDataExpire(refreshToken, valueToStore , ttl);
     }
 
-    public void expiredRefreshToken(String refreshToken) {
+    public void expiredRefreshTokenAtRedis(String refreshToken) {
         String data = jwtRedisUtil.getData(refreshToken); // 해당 리프레시 토큰 무효화
         if (data == null) {
             return;
@@ -222,6 +255,11 @@ public class JwtTokenProvider {
         try {
             // 토큰 데이터를 JSON 형태로 변환한다,
             JsonNode tokenData = objectMapper.readTree(data);
+
+            // 이미 만료된 토큰이라면 종료
+            if (Objects.equals(tokenData.get("status").asText(), "expired")) {
+                return;
+            }
 
             // 상태 정보를 expired 로 변경한다.
             ((ObjectNode) tokenData).put("status", "expired");
@@ -267,5 +305,10 @@ public class JwtTokenProvider {
             log.info(e.getMessage());
             throw new CustomException(SERVER_ERROR);
         }
+    }
+
+    private void saveLoginListWithRefreshTokenAtRedis(String userUUID, String refreshToken, Instant refreshTokenExpiresIn) {
+        long ttl = Duration.between(Instant.now(), refreshTokenExpiresIn).toMillis();
+        loginListRedisUtil.setDataExpire(userUUID, refreshToken , ttl);
     }
 }

--- a/src/main/java/shootingstar/var/util/LoginListRedisUtil.java
+++ b/src/main/java/shootingstar/var/util/LoginListRedisUtil.java
@@ -1,0 +1,41 @@
+package shootingstar.var.util;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class LoginListRedisUtil {
+    private final RedisTemplate<String, Object> loginListRedis;
+
+    public LoginListRedisUtil(@Qualifier("loginListRedisTemplate") RedisTemplate<String, Object> loginListRedis) {
+        this.loginListRedis = loginListRedis;
+    }
+
+    public void setData(String key, String value){
+        loginListRedis.opsForValue().set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, long milliseconds){
+        loginListRedis.opsForValue().set(key, value, milliseconds, TimeUnit.MILLISECONDS);
+    }
+
+    public String getData(String key){
+        return (String) loginListRedis.opsForValue().get(key);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(loginListRedis.hasKey(key));
+    }
+
+    public void deleteData(String key){
+        loginListRedis.unlink(key);
+    }
+
+    public void deleteAll() {
+        Objects.requireNonNull(loginListRedis.getConnectionFactory()).getConnection().serverCommands().flushAll();
+    }
+}


### PR DESCRIPTION
로그아웃 구현

중복 로그인 방지 추가

액세스 토큰 만료시간은 30분으로 잡을 예정입니다.

- 중복 로그인 방지를 위해 로그인 리스트를 저장하는 레디스 추가
- 로그인시 로그인 리스트에서 해당 사용자를 찾고 존재한다면 이전 리프레시 토큰을 만료시키고
  로그인 리스트에 상태를 업데이트 합니다.
- 로그인 리스트에 해당 사용자가 없다면 로그인 리스트에 추가합니다.
- 로그인 리스트 레디스와 토큰 레디스에 저장되는 값은 해당하는 리프레시 토큰의 생명주기와 같습니다.
  레디스에서 생명주기가 끝난 데이터는 자동으로 삭제됩니다.

- 액세스 토큰 재발급시 현재 로그인 리스트에 등록된 리프레시 토큰 정보가 다르다면
  다른 장소에서 로그인 되었다는 에러를 반환합니다.
- 토큰 재발급시 토큰 관련 에러가 발생했을 경우 쿠키에 존재하는 토큰을 제거합니다.

- 로그아웃의 경우 리프레시 토큰을 검증하지만 에러를 반환하지 않습니다.
  로그아웃 행위의 목적은 리프레시 토큰 만료가 목적이기에
  로그만 남기고 성공했다고 반환합니다.
- 토큰 문제 없이 로그아웃에 성공하였을경우 로그인 리스트에서 해당 사용자를 삭제합니다.
- 로그아웃 프로세스가 종료되면 쿠키에 존재하는 토큰을 제거합니다.