### PR TITLE
Feat : 회원 탈퇴, 액세스 토큰 검증 추가

### DIFF
--- a/src/main/java/shootingstar/var/Service/CheckDuplicateService.java
+++ b/src/main/java/shootingstar/var/Service/CheckDuplicateService.java
@@ -10,10 +10,10 @@ public class CheckDuplicateService {
     private final UserRepository userRepository;
 
     public boolean checkNicknameDuplicate(String nickname) {
-        return userRepository.existsByNickname(nickname);
+        return userRepository.existsByNicknameAndIsWithdrawn(nickname, false);
     }
 
     public boolean checkEmailDuplicate(String email) {
-        return userRepository.existsByEmail(email);
+        return userRepository.existsByEmailAndIsWithdrawn(email, false);
     }
 }

--- a/src/main/java/shootingstar/var/Service/UserAuthService.java
+++ b/src/main/java/shootingstar/var/Service/UserAuthService.java
@@ -87,7 +87,7 @@ public class UserAuthService {
     }
 
     @Transactional
-    public void withdrawal(String userUUID, String refreshToken) {
+    public String withdrawal(String userUUID, String refreshToken) {
         User user = userRepository.findByUserUUID(userUUID)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -110,5 +110,7 @@ public class UserAuthService {
         // 진행중인 식사권에 대한 거부 로직도 필요
 
         user.withdrawn();
+
+        return user.getKakaoId();
     }
 }

--- a/src/main/java/shootingstar/var/Service/UserAuthService.java
+++ b/src/main/java/shootingstar/var/Service/UserAuthService.java
@@ -1,11 +1,14 @@
 package shootingstar.var.Service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.stereotype.Service;
+import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.AuctionType;
 import shootingstar.var.entity.User;
 import shootingstar.var.exception.CustomException;
 import shootingstar.var.jwt.JwtTokenProvider;
@@ -17,8 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static shootingstar.var.exception.ErrorCode.INVALID_REFRESH_TOKEN;
-import static shootingstar.var.exception.ErrorCode.LOGGED_IN_SOMEWHERE_ELSE;
+import static shootingstar.var.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -48,11 +50,16 @@ public class UserAuthService {
 
     public Authentication loadUserByKakaoId(String kakaoId) {
         // 카카오 ID로 사용자 조회
-        Optional<User> findUser = userRepository.findByKakaoId(kakaoId);
+        Optional<User> findUser = userRepository.findByKakaoIdAndIsWithdrawn(kakaoId, false);
 
         // 이미 존재하는 사용자인 경우
         if (findUser.isPresent()) {
             User user = findUser.get();
+
+            if (user.getWarningCount() == 3) {
+                throw new CustomException(BANNED_USER);
+            }
+
             List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList(user.getUserType().toString());
 
             // 사용자 UUID를 기반으로 Authentication 객체 생성 및 반환
@@ -77,5 +84,31 @@ public class UserAuthService {
             tokenProvider.expiredRefreshTokenAtRedis(storeRefreshToken); // 로그인 리스트에 등록된 토큰도 만료 시킨다.
         }
         loginListRedisUtil.deleteData(userUUID); // 로그인 리스트에서 사용자 정보를 제거한다.
+    }
+
+    @Transactional
+    public void withdrawal(String userUUID, String refreshToken) {
+        User user = userRepository.findByUserUUID(userUUID)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        tokenProvider.expiredRefreshTokenAtRedis(refreshToken);
+
+        String storeRefreshToken = loginListRedisUtil.getData(userUUID); // 로그인 리스트에 등록된 토큰
+        if (!Objects.equals(storeRefreshToken, refreshToken)) { // 로그인 리스트와 현재 등록된 토큰이 다를 경우
+            tokenProvider.expiredRefreshTokenAtRedis(storeRefreshToken); // 로그인 리스트에 등록된 토큰도 만료 시킨다.
+        }
+        loginListRedisUtil.deleteData(userUUID); // 로그인 리스트에서 사용자 정보를 제거한다.
+
+        // 진행중인 경매 혹은 진행중인 식사권이 있다면 회원탈퇴를 거부
+        boolean hasInProgressAuction = user.getMyHostedAuction().stream()
+                .anyMatch(auction -> AuctionType.PROGRESS.equals(auction.getAuctionType()));
+
+        if (hasInProgressAuction) {
+            throw new CustomException(WITHDRAWAL_ERROR_BY_AUCTION_IN_PROGRESS);
+        }
+
+        // 진행중인 식사권에 대한 거부 로직도 필요
+
+        user.withdrawn();
     }
 }

--- a/src/main/java/shootingstar/var/config/SecurityConfig.java
+++ b/src/main/java/shootingstar/var/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                                 ).denyAll()
 
                                 .requestMatchers( // 인증 후 접근 허용
-                                        "/api/auth/delete/user"
+                                        "/api/auth/withdrawal"
                                 ).authenticated()
 
                                 .requestMatchers( // 인증 없이 접근 허용

--- a/src/main/java/shootingstar/var/controller/UserAuthController.java
+++ b/src/main/java/shootingstar/var/controller/UserAuthController.java
@@ -143,7 +143,8 @@ public class UserAuthController {
         String userUUID = tokenProvider.getUserUUIDByRequest(request);
         String refreshToken = TokenUtil.getTokenFromCookie(request);
 
-        authService.withdrawal(userUUID, refreshToken);
+        String kakaoId = authService.withdrawal(userUUID, refreshToken);
+        kakaoAPI.unlinkUser(kakaoId);
 
         TokenUtil.updateCookie(response, null, 0);
 

--- a/src/main/java/shootingstar/var/controller/UserAuthController.java
+++ b/src/main/java/shootingstar/var/controller/UserAuthController.java
@@ -27,8 +27,6 @@ import shootingstar.var.oAuth.KakaoAPI;
 import shootingstar.var.oAuth.KakaoUserInfo;
 import shootingstar.var.util.TokenUtil;
 
-import static shootingstar.var.exception.ErrorCode.INVALID_REFRESH_TOKEN;
-
 @Tag(name = "인증 컨트롤러", description = "사용자 인증 관련 컨트롤러")
 @RestController
 @Slf4j
@@ -54,7 +52,8 @@ public class UserAuthController {
                                     "- 카카오로부터 ACCESS 토큰 획득에 실패 : 0110\n" +
                                     "- 카카오 토큰 엔드포인트와 통신에 실패 : 0111\n" +
                                     "- 카카오로부터 사용자 정보를 가져오지 못했을 때 : 0112\n" +
-                                    "- 카카오 사용자 정보 엔드포인트와 통신에 실패 : 0113",
+                                    "- 카카오 사용자 정보 엔드포인트와 통신에 실패 : 0113\n" +
+                                    "- 경고 3회 누적으로 정지된 사용자 : 1103",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @PostMapping("/oauth2/accessKakao")
@@ -112,20 +111,20 @@ public class UserAuthController {
                     @Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))}),
             @ApiResponse(responseCode = "403",
                     description =
-                                     "- 잘못된 RefreshToken : 0106\n" +
+                                    "- 잘못된 RefreshToken : 0106\n" +
                                     "- 만료된 RefreshToken : 0107\n" +
                                     "- 지원하지 않는 RefreshToken : 0108\n" +
                                     "- Claim이 빈 Refresh Token : 0109\n" +
                                     "- 다른 장소에서 로그인 됨 : 0114",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "500",
-            description = "Redis JSON 파싱 에러",
-            content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+                    description = "Redis JSON 파싱 에러",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @PostMapping("/refresh")
     public ResponseEntity<String> refresh(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = TokenUtil.getTokenFromCookie(request);
-        
+
         String newAccessToken;
         try {
             newAccessToken = authService.refreshAccessToken(refreshToken);
@@ -137,5 +136,17 @@ public class UserAuthController {
             TokenUtil.updateCookie(response, null, 0);
             throw new CustomException(errorCode);
         }
+    }
+
+    @PatchMapping("/withdrawal")
+    public ResponseEntity<String> withdrawal(HttpServletRequest request, HttpServletResponse response) {
+        String userUUID = tokenProvider.getUserUUIDByRequest(request);
+        String refreshToken = TokenUtil.getTokenFromCookie(request);
+
+        authService.withdrawal(userUUID, refreshToken);
+
+        TokenUtil.updateCookie(response, null, 0);
+
+        return ResponseEntity.ok().body("성공적으로 회원탈퇴 되었습니다.");
     }
 }

--- a/src/main/java/shootingstar/var/entity/User.java
+++ b/src/main/java/shootingstar/var/entity/User.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -55,6 +57,12 @@ public class User extends BaseTimeEntity {
 
     private Integer warningCount;
 
+    private Boolean isWithdrawn;
+    private LocalDateTime withdrawnTime;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private final List<Auction> myHostedAuction = new ArrayList<>();
+
     @Builder
     public User(String kakaoId, String name, String nickname, String phone, String email, String profileImgUrl, UserType userType) {
         this.userUUID = UUID.randomUUID().toString();
@@ -70,6 +78,8 @@ public class User extends BaseTimeEntity {
         this.rating = null;
         this.subscribe = null;
         this.warningCount = 0;
+        this.isWithdrawn = false;
+        this.withdrawnTime = null;
     }
 
     public void increasePoint(long point) {
@@ -78,5 +88,10 @@ public class User extends BaseTimeEntity {
 
     public void decreasePoint(long point) {
         this.point -= point;
+    }
+
+    public void withdrawn() {
+        this.isWithdrawn = true;
+        this.withdrawnTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -42,11 +42,13 @@ public enum ErrorCode {
 
     AUTH_ERROR_EMAIL(UNAUTHORIZED, "1101", "잘못된 키 혹은 잘못(만료) 된 인증 코드입니다."),
     VALIDATE_ERROR_EMAIL(UNAUTHORIZED, "1102", "인증이 만료되었거나 인증되지 않은 이메일입니다."),
+    BANNED_USER(UNAUTHORIZED, "1103", "경고 3회 누적으로 정지된 사용자입니다."),
 
     USER_NOT_FOUND(NOT_FOUND, "1201", "존재하지 않는 사용자입니다."),
 
     DUPLICATE_EMAIL(CONFLICT, "1301", "이미 사용중인 이메일입니다."),
     DUPLICATE_NICKNAME(CONFLICT, "1302", "이미 사용중인 닉네임입니다."),
+    WITHDRAWAL_ERROR_BY_AUCTION_IN_PROGRESS(CONFLICT, "1303", "현재 진행중인 경매가 존재할 경우 회원탈퇴가 불가능합니다."),
 
     MIN_BID_AMOUNT_INCORRECT_FORMAT(BAD_REQUEST, "2000", "최소입찰금액은 자신의 보유 포인트보다 적어야 합니다."),
     AUCTION_ACCESS_DENIED(FORBIDDEN, "2100", "접근 권한이 없습니다."),

--- a/src/main/java/shootingstar/var/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/shootingstar/var/jwt/JwtAuthenticationFilter.java
@@ -60,8 +60,11 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             이 때 만약 잘못된 토큰 값이라면 토큰 에러를 반환한다.
          */
         try {
-            if (token != null && jwtTokenProvider.validateToken(token)) {
+            if (token != null && jwtTokenProvider.validateAccessToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(token);
+                if (!jwtTokenProvider.isLoginUser(authentication.getName())) {
+                    throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+                }
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (CustomException e) {

--- a/src/main/java/shootingstar/var/oAuth/KakaoAPI.java
+++ b/src/main/java/shootingstar/var/oAuth/KakaoAPI.java
@@ -23,6 +23,8 @@ public class KakaoAPI {
     private String redirectURI;
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
+    @Value("${admin-key}")
+    private String adminKey;
 
     private final RestTemplate restTemplate;
 
@@ -74,6 +76,26 @@ public class KakaoAPI {
             } else {
                 throw new CustomException(KAKAO_FAILED_GET_USERINFO_ERROR);
             }
+        } catch (RestClientException e) {
+            throw new CustomException(KAKAO_CONNECT_FAILED_USERINFO_ENDPOINT);
+        }
+    }
+
+    public void unlinkUser(String kakaoId) {
+        String unlinkUserEndpoint = "https://kapi.kakao.com/v1/user/unlink";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("Authorization", "KakaoAK " + adminKey); // 어드민 키 사용
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", String.valueOf(kakaoId));
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            restTemplate.exchange(unlinkUserEndpoint, HttpMethod.POST, requestEntity, String.class);
         } catch (RestClientException e) {
             throw new CustomException(KAKAO_CONNECT_FAILED_USERINFO_ENDPOINT);
         }

--- a/src/main/java/shootingstar/var/repository/UserRepository.java
+++ b/src/main/java/shootingstar/var/repository/UserRepository.java
@@ -7,11 +7,11 @@ import shootingstar.var.entity.User;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
-    Optional<User> findByKakaoId(String kakaoId);
+    Optional<User> findByKakaoIdAndIsWithdrawn(String kakaoId, Boolean isWithdrawn);
 
     Optional<User> findByUserUUID(String uuid);
-    boolean existsByNickname(String nickname);
-    boolean existsByEmail(String email);
+    boolean existsByNicknameAndIsWithdrawn(String nickname, Boolean isWithdrawn);
+    boolean existsByEmailAndIsWithdrawn(String email, Boolean isWithdrawn);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByUserId(Long followingId);
 }


### PR DESCRIPTION
### 회원 탈퇴 API를 개발하였습니다.
- 진행중인 식사권에 대한 예러는 미구현입니다.
- 진행중인 경매가 있다면 에러를 반환합니다.
- user를 삭제하지 않고 isWithdrawn과 withdrawnTime을 변경합니다.
- 회원탈퇴시 카카오 연결을 끊습니다.

### 사용자 엔티티를 수정하였습니다.
- 회원 탈퇴를 위한 필드 2개를 추가하였습니다.
- 자신의 경매 리스트를 조회하기 위해 양방향 맵핑을 추가하였습니다.
- 회원 탈퇴 로직을 추가하였습니다.

### 사용자 레포지토리를 수정하였습니다.
- 탈퇴된 회원을 제외하고 검색하기 위해 AndIsWithdrawn을 추가하였습니다.
  - 카카오 사용자, 닉네임 중복, 이메일 중복에 추가하였습니다.
- 사용자 조회시 위와 같은 조건을 사용해 탈퇴된 회원을 구분하여야 합니다.

### JwtFilter에 액세스 토큰에 대한 검증 로직을 추가하였습니다.
- 로그인 리스트에서 현재 로그인 중인 사용자가 아니라면 에러를 반환합니다.

### JwtProvider에 로직과 주석을 추가하였습니다.
- 로그인 리스트에 현재 사용자가 있는지 검사하는 로직을 추가하였습니다.

### 로그인시 로직을 추가하였습니다.
- 카카오 ID로 사용자 존재를 확인할 떄 탈퇴된 회원은 검색하지 않습니다.
- 3회 경고를 받은 회원은 토큰을 발급하지 않고 해당 에러를 반환합니다.

### ErrorCode를 추가하였습니다.
- 정지된 사용자, 진행중인 경매 존재로 회원탈퇴 실패