### PR TITLE
Feat: 식사권 신고 API

### DIFF
--- a/src/main/java/shootingstar/var/Service/AuctionService.java
+++ b/src/main/java/shootingstar/var/Service/AuctionService.java
@@ -115,8 +115,8 @@ public class AuctionService {
             throw new CustomException(ErrorCode.AUCTION_ACCESS_DENIED);
         }
 
-        // 경매 타입이 CANCEL인지 확인
-        if (findAuction.getAuctionType().equals(AuctionType.CANCEL)) {
+        // 경매 타입이 PROGRESS인지 확인
+        if (!findAuction.getAuctionType().equals(AuctionType.PROGRESS)) {
             throw new CustomException(ErrorCode.AUCTION_CONFLICT);
         }
 

--- a/src/main/java/shootingstar/var/Service/TicketService.java
+++ b/src/main/java/shootingstar/var/Service/TicketService.java
@@ -73,7 +73,7 @@ public class TicketService {
         TicketMeetingTime findTicketMeetingTime = ticketMeetingTimeRepository.findByTicketIdAndUserNickname(reqDto.getTicketId(), findUser.getNickname())
                 .orElse(null);
         if (findTicketMeetingTime != null) {
-            throw new CustomException(ErrorCode.TICKET_CONFLICT);
+            throw new CustomException(ErrorCode.TICKET_MEETING_TIME_CONFLICT);
         }
 
         // 로그인한 사용자에 해당하는 식사권의 만남 시작 버튼 누른 여부를 true로 변경

--- a/src/main/java/shootingstar/var/controller/TicketController.java
+++ b/src/main/java/shootingstar/var/controller/TicketController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shootingstar.var.Service.TicketService;
 import shootingstar.var.dto.req.MeetingTimeSaveReqDto;
+import shootingstar.var.dto.req.TicketReportReqDto;
 import shootingstar.var.dto.res.DetailTicketResDto;
 import shootingstar.var.dto.res.MeetingTimeResDto;
 import shootingstar.var.exception.ErrorResponse;
@@ -101,5 +102,31 @@ public class TicketController {
         String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
         LocalDateTime startMeetingTime = ticketService.findMeetingTimeByTicketUUID(ticketUUID, userUUID);
         return ResponseEntity.ok().body(new MeetingTimeResDto(startMeetingTime));
+    }
+
+    @Operation(summary = "식사권 신고하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "- 사용자 타입이 VIP, BASIC일 때 : 식사권 신고 성공"),
+            @ApiResponse(responseCode = "400",
+                    description =
+                                    "- 잘못된 형식의 식사권 신고 내용 입력 시 : 6003\n" +
+                                    "- 잘못된 형식의 식사권 신고 증거 URL 입력 시 : 6004\n",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404",
+                    description = "- 식사권 정보 조회 실패 : 6200",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "403",
+                    description = "- 로그인한 사용자가 식사권의 낙찰자도 주최자도 아닐 때 : 0101",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "409",
+                    description = "- 이미 같은 식사권에 신고한 적이 있는 경우 : 6301",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping("/report")
+    public ResponseEntity<String> reportTicket(@Valid @RequestBody TicketReportReqDto reqDto, HttpServletRequest request) {
+        String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
+        ticketService.reportTicket(reqDto, userUUID);
+        return ResponseEntity.ok().body("식사권 신고 성공");
     }
 }

--- a/src/main/java/shootingstar/var/dto/req/TicketReportReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/TicketReportReqDto.java
@@ -1,0 +1,17 @@
+package shootingstar.var.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class TicketReportReqDto {
+    @NotNull
+    private Long ticketId;
+
+    @NotBlank
+    private String ticketReportContent;
+
+    @NotBlank
+    private String ticketReportEvidenceUrl;
+}

--- a/src/main/java/shootingstar/var/entity/TicketReport.java
+++ b/src/main/java/shootingstar/var/entity/TicketReport.java
@@ -1,0 +1,56 @@
+package shootingstar.var.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class TicketReport extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketReportId;
+
+    private String ticketReportUUID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id")
+    private Ticket ticket;
+
+    @NotBlank
+    private String ticketReportNickname;
+
+    @Lob
+    @NotBlank
+    private String ticketReportContent;
+
+    @NotBlank
+    private String ticketReportEvidenceUrl;
+
+    @Enumerated(value = EnumType.STRING)
+    private TicketReportStatus ticketReportStatus;
+
+    @Builder
+    public TicketReport(Ticket ticket, String ticketReportNickname, String ticketReportContent,
+                        String ticketReportEvidenceUrl) {
+        this.ticketReportUUID = UUID.randomUUID().toString();
+        this.ticket = ticket;
+        this.ticketReportNickname = ticketReportNickname;
+        this.ticketReportContent = ticketReportContent;
+        this.ticketReportEvidenceUrl = ticketReportEvidenceUrl;
+        this.ticketReportStatus = TicketReportStatus.STANDBY;
+    }
+}

--- a/src/main/java/shootingstar/var/entity/TicketReportStatus.java
+++ b/src/main/java/shootingstar/var/entity/TicketReportStatus.java
@@ -1,0 +1,5 @@
+package shootingstar.var.entity;
+
+public enum TicketReportStatus {
+    REFUSAL, STANDBY, APPROVE
+}

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -80,7 +80,7 @@ public enum ErrorCode {
     TICKET_NOT_FOUND(NOT_FOUND, "6200", "존재하지 않는 식사권입니다."),
     TICKET_MEETING_TIME_NOT_FOUND(NOT_FOUND, "6201", "존재하지 않는 만남 시작 시간입니다."),
 
-    TICKET_CONFLICT(CONFLICT, "6300", "이미 처리된 식사권 만남 시간입니다."),
+    TICKET_MEETING_TIME_CONFLICT(CONFLICT, "6300", "이미 처리된 식사권 만남 시간입니다."),
     TICKET_REPORT_CONFLICT(CONFLICT, "6301", "이미 신고된 식사권입니다."),
     ;
 

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -74,11 +74,14 @@ public enum ErrorCode {
 
     INCORRECT_FORMAT_TICKET_ID(BAD_REQUEST, "6001", "잘못된 형식의 식사권 고유번호입니다."),
     INCORRECT_FORMAT_START_MEETING_TIME(BAD_REQUEST, "6002", "잘못된 형식의 만남 시작 시간입니다."),
+    INCORRECT_FORMAT_TICKET_REPORT_CONTENT(BAD_REQUEST, "6003", "잘못된 형식의 식사권 신고 내용입니다."),
+    INCORRECT_FORMAT_TICKET_REPORT_EVIDENCE_URL(BAD_REQUEST, "6004", "잘못된 형식의 식사권 신고 증거 URL입니다."),
 
     TICKET_NOT_FOUND(NOT_FOUND, "6200", "존재하지 않는 식사권입니다."),
     TICKET_MEETING_TIME_NOT_FOUND(NOT_FOUND, "6201", "존재하지 않는 만남 시작 시간입니다."),
 
     TICKET_CONFLICT(CONFLICT, "6300", "이미 처리된 식사권 만남 시간입니다."),
+    TICKET_REPORT_CONFLICT(CONFLICT, "6301", "이미 신고된 식사권입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
+++ b/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
@@ -70,6 +70,12 @@ public class GlobalExceptionHandler {
                 } case "startMeetingTime" -> {
                     errorCode = INCORRECT_FORMAT_START_MEETING_TIME;
                     break;
+                } case "ticketReportContent" -> {
+                    errorCode = INCORRECT_FORMAT_TICKET_REPORT_CONTENT;
+                    break;
+                } case "ticketReportEvidenceUrl" -> {
+                    errorCode = INCORRECT_FORMAT_TICKET_REPORT_EVIDENCE_URL;
+                    break;
                 }
             }
 

--- a/src/main/java/shootingstar/var/repository/TicketReportRepository.java
+++ b/src/main/java/shootingstar/var/repository/TicketReportRepository.java
@@ -1,0 +1,11 @@
+package shootingstar.var.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import shootingstar.var.entity.TicketReport;
+
+public interface TicketReportRepository extends JpaRepository<TicketReport, Long> {
+    @Query("select tr from TicketReport tr where tr.ticket.ticketId = :ticketId and tr.ticketReportNickname = :ticketReportNickname")
+    Optional<TicketReport> findByTicketIdAndTicketReportNickname(Long ticketId, String ticketReportNickname);
+}


### PR DESCRIPTION
식사권 신고 로직
- 로그인한 사용자가 경매의 낙찰자도 주최자도 아닐 때, 에러 처리
- 로그인한 사용자가 이미 해당 식사권에 대해 신고 경험이 있는 경우, 에러 처리
- 식사권 신고 데이터 저장