### PR TITLE
Feat: 식사권 취소 API, 포인트 타입 Long => BigDecimal

### DIFF
--- a/src/main/java/shootingstar/var/Service/AuctionService.java
+++ b/src/main/java/shootingstar/var/Service/AuctionService.java
@@ -1,5 +1,6 @@
 package shootingstar.var.Service;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -51,8 +52,13 @@ public class AuctionService {
         User findUser = userRepository.findByUserUUID(userUUID)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        // 최소 입찰 금액이 10000원 단위가 아닐 경우
+        if (reqDto.getMinBidAmount() % 10000 != 0) {
+            throw new CustomException(ErrorCode.INCORRECT_FORMAT_MIN_BID_AMOUNT);
+        }
+
         // 보유 포인트보다 최소 입찰 금액이 더 클 경우
-        if (findUser.getPoint() < reqDto.getMinBidAmount()) {
+        if (findUser.getPoint().compareTo(BigDecimal.valueOf(reqDto.getMinBidAmount())) == -1) {
             throw new CustomException(ErrorCode.MIN_BID_AMOUNT_INCORRECT_FORMAT);
         }
 
@@ -71,7 +77,9 @@ public class AuctionService {
         auctionRepository.save(auction);
 
         // 포인트 차감
-        findUser.decreasePoint(auction.getMinBidAmount());
+        log.info("사용자 감소 전 포인트 : {}", findUser.getPoint());
+        findUser.decreasePoint(BigDecimal.valueOf(auction.getMinBidAmount()));
+        log.info("사용자 감소 후 포인트 : {}", findUser.getPoint());
 
         // 스케줄링 저장
         LocalDateTime scheduleTime = LocalDateTime.now().plusMinutes(1);
@@ -129,22 +137,22 @@ public class AuctionService {
             User findCurrentHighestBidder = userRepository.findByUserUUID(findAuction.getCurrentHighestBidderId())
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-            long beforePoint = findCurrentHighestBidder.getPoint();
+            BigDecimal beforePoint = findCurrentHighestBidder.getPoint();
             log.info("포인트가 추가될 예정입니다. userId : {}, 추가 전 포인트 : {}", findCurrentHighestBidder.getUserId(), beforePoint);
 
-            findCurrentHighestBidder.increasePoint(findAuction.getCurrentHighestBidAmount());
+            findCurrentHighestBidder.increasePoint(BigDecimal.valueOf(findAuction.getCurrentHighestBidAmount()));
 
-            long afterPoint = findCurrentHighestBidder.getPoint();
+            BigDecimal afterPoint = findCurrentHighestBidder.getPoint();
             log.info("포인트가 추가되었습니다. userId : {}, 추가 후 포인트 : {}", findCurrentHighestBidder.getUserId(), afterPoint);
         }
 
         // 사용자 포인트에 += 최소입찰금액
-        long beforePoint = findAuction.getUser().getPoint();
+        BigDecimal beforePoint = findAuction.getUser().getPoint();
         log.info("포인트가 추가될 예정입니다. userId : {}, 추가 전 포인트 : {}", findAuction.getUser().getUserId(), beforePoint);
 
-        findAuction.getUser().increasePoint(findAuction.getMinBidAmount());
+        findAuction.getUser().increasePoint(BigDecimal.valueOf(findAuction.getMinBidAmount()));
 
-        long afterPoint = findAuction.getUser().getPoint();
+        BigDecimal afterPoint = findAuction.getUser().getPoint();
         log.info("포인트가 추가되었습니다. userId : {}, 추가 후 포인트 : {}", findAuction.getUser().getUserId(), afterPoint);
 
 

--- a/src/main/java/shootingstar/var/Service/PaymentService.java
+++ b/src/main/java/shootingstar/var/Service/PaymentService.java
@@ -3,6 +3,7 @@ package shootingstar.var.Service;
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.response.IamportResponse;
 import com.siot.IamportRestClient.response.Payment;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -44,7 +45,7 @@ public class PaymentService {
         PaymentsInfo paymentsInfo = new PaymentsInfo(user, amount);
         paymentRepository.save(paymentsInfo);
 
-        user.increasePoint(amount);
+        user.increasePoint(BigDecimal.valueOf(amount));
     }
 
     @Transactional
@@ -56,7 +57,7 @@ public class PaymentService {
             throw new CustomException(DIFFERENT_ACCOUNT_HOLDER);
         }
 
-        if (exchangeReqDto.getExchangePoint() > user.getPoint()) {
+        if (new BigDecimal(exchangeReqDto.getExchangePoint()).compareTo(user.getPoint()) == 1) {
             throw new CustomException(EXCHANGE_AMOUNT_INCORRECT_FORMAT);
         }
 
@@ -70,6 +71,6 @@ public class PaymentService {
 
         exchangeFormRepository.save(exchangeForm);
 
-        user.decreasePoint(exchangeReqDto.getExchangePoint());
+        user.decreasePoint(BigDecimal.valueOf(exchangeReqDto.getExchangePoint()));
     }
 }

--- a/src/main/java/shootingstar/var/Service/SchedulerService.java
+++ b/src/main/java/shootingstar/var/Service/SchedulerService.java
@@ -1,5 +1,6 @@
 package shootingstar.var.Service;
 
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,7 +46,7 @@ public class SchedulerService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
             log.info("사용자 증가 전 포인트 : {}", user.getPoint());
-            user.increasePoint(auction.getMinBidAmount());
+            user.increasePoint(BigDecimal.valueOf(auction.getMinBidAmount()));
             log.info("사용자 증가 후 포인트 : {}", user.getPoint());
 
             ScheduledTask task = scheduledTaskRepository.findById(scheduledTaskId)

--- a/src/main/java/shootingstar/var/Service/TicketService.java
+++ b/src/main/java/shootingstar/var/Service/TicketService.java
@@ -1,9 +1,12 @@
 package shootingstar.var.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shootingstar.var.dto.req.MeetingTimeSaveReqDto;
@@ -21,6 +24,7 @@ import shootingstar.var.repository.TicketReportRepository;
 import shootingstar.var.repository.TicketRepository;
 import shootingstar.var.repository.UserRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TicketService {
@@ -28,6 +32,7 @@ public class TicketService {
     private final TicketMeetingTimeRepository ticketMeetingTimeRepository;
     private final TicketReportRepository ticketReportRepository;
     private final UserRepository userRepository;
+    private final ObjectProvider<TicketService> ticketServiceProvider;
 
     public DetailTicketResDto detailTicket(String ticketUUID, String userUUID) {
         Ticket ticket = ticketRepository.findByTicketUUID(ticketUUID)
@@ -42,13 +47,14 @@ public class TicketService {
         User winner = userRepository.findByUserUUID(auction.getCurrentHighestBidderId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        BigDecimal donationCommission = new BigDecimal(0.05);
         return DetailTicketResDto.builder()
                 .meetingDate(auction.getMeetingDate())
                 .meetingLocation(auction.getMeetingLocation())
                 .organizerNickname(auction.getUser().getNickname())
                 .winnerNickname(winner.getNickname())
                 .winningBid(auction.getCurrentHighestBidAmount())
-                .donation(auction.getCurrentHighestBidAmount() * 0.05)
+                .donation(BigDecimal.valueOf(auction.getCurrentHighestBidAmount()).multiply(donationCommission))
                 .meetingInfoText(auction.getMeetingInfoText())
                 .meetingPromiseText(auction.getMeetingPromiseText())
                 .winnerIsPushed(ticket.isWinnerIsPushed())
@@ -112,6 +118,7 @@ public class TicketService {
         return ticketMeetingTimes.get(1).getStartMeetingTime();
     }
 
+    @Transactional
     public void reportTicket(TicketReportReqDto reqDto, String userUUID) {
         Ticket ticket = ticketRepository.findById(reqDto.getTicketId())
                 .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
@@ -142,5 +149,104 @@ public class TicketService {
                 .ticketReportEvidenceUrl(reqDto.getTicketReportEvidenceUrl())
                 .build();
         ticketReportRepository.save(ticketReport);
+    }
+
+    @Transactional
+    public void cancelTicket(String ticketUUID, String userUUID) {
+        Ticket ticket = ticketRepository.findByTicketUUID(ticketUUID)
+                .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
+
+        // 로그인한 사용자가 경매의 낙찰자도 주최자도 아닐 때
+        if (!ticket.getWinner().getUserUUID().equals(userUUID) && !ticket.getOrganizer().getUserUUID().equals(userUUID)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        LocalDateTime meetingDateTime = ticket.getAuction().getMeetingDate();
+        LocalDate meetingDate = LocalDate.of(meetingDateTime.getYear(), meetingDateTime.getMonth(),
+                meetingDateTime.getDayOfMonth());
+
+        // 현재 시간이 식사 날짜 시간을 지났을 때
+        if (LocalDateTime.now().isAfter(meetingDateTime)) {
+            throw new CustomException(ErrorCode.TICKET_CANCEL_CONFLICT);
+        }
+
+        // 식사권이 닫혔을 때
+        if (!ticket.isTicketIsOpened()) {
+            throw new CustomException(ErrorCode.ALREADY_TICKET_CANCEL_CONFLICT);
+        }
+
+        TicketService ticketService = ticketServiceProvider.getObject();
+        // 로그인한 사용자가 낙찰자일 때
+        if (ticket.getWinner().getUserUUID().equals(userUUID)) {
+            ticketService.cancelTicketByWinner(ticket, meetingDate, meetingDateTime);
+
+            // 로그인한 사용자가 주최자일 때
+        } else if (ticket.getOrganizer().getUserUUID().equals(userUUID)) {
+            ticketService.cancelTicketByOrganizer(ticket);
+        }
+
+        // 채팅방 닫는 로직
+
+        // 식사권 상태 false로 변경
+        ticket.changeTicketIsOpened(false);
+    }
+
+    @Transactional
+    void cancelTicketByWinner(Ticket ticket, LocalDate meetingDate, LocalDateTime meetingDateTime) {
+        log.info("-----------낙찰자 식사권 취소");
+
+        BigDecimal zero = new BigDecimal(0);
+        BigDecimal vipCommission = calculateCommission(meetingDate, meetingDateTime);
+
+        // 주최자에게 수수료 제공
+        if (vipCommission.compareTo(zero) == 1) {
+            log.info("주최자 수수료 받기 전 포인트 : {}", ticket.getOrganizer().getPoint());
+            ticket.getOrganizer().increasePoint(BigDecimal.valueOf(ticket.getAuction().getCurrentHighestBidAmount()).multiply(vipCommission));
+            log.info("주최자 수수료 받은 후 포인트 : {}", ticket.getOrganizer().getPoint());
+        }
+
+        BigDecimal basicCommission = new BigDecimal(0.7).subtract(vipCommission);
+        // 낙찰자에게 수수료 제외한 금액 반환
+        if (basicCommission.compareTo(zero) == 1) {
+            log.info("낙찰자 수수료 받기 전 포인트 : {}", ticket.getWinner().getPoint());
+            ticket.getWinner().increasePoint(BigDecimal.valueOf(ticket.getAuction().getCurrentHighestBidAmount()).multiply(basicCommission));
+            log.info("낙찰자 수수료 받은 후 포인트 : {}", ticket.getWinner().getPoint());
+        }
+
+        // 주최자에게 최소 입찰 금액 반환
+        log.info("주최자 수수료 받기 전 포인트 : {}", ticket.getOrganizer().getPoint());
+        ticket.getOrganizer().increasePoint(BigDecimal.valueOf(ticket.getAuction().getMinBidAmount()));
+        log.info("주최자 수수료 받은 후 포인트 : {}", ticket.getOrganizer().getPoint());
+    }
+
+    private BigDecimal calculateCommission(LocalDate meetingDate, LocalDateTime meetingDateTime) {
+        BigDecimal extraCommission = new BigDecimal(0);
+        // 식사 21일 ~ 15일 전
+        if (LocalDate.now().isAfter(meetingDate.minusDays(22)) && LocalDate.now().isBefore(meetingDate.minusDays(14))) {
+            extraCommission = new BigDecimal(0.1);
+
+            //  식사 14일 ~ 8일 전
+        } else if (LocalDate.now().isAfter(meetingDate.minusDays(15)) && LocalDate.now().isBefore(meetingDate.minusDays(7))) {
+            extraCommission = new BigDecimal(0.3);
+
+            // 식사 7일 ~ 1일 전
+        } else if (LocalDate.now().isAfter(meetingDate.minusDays(8)) && LocalDate.now().isBefore(meetingDate)) {
+            extraCommission = new BigDecimal(0.5);
+
+            // 식사 당일 환불(식사 시간 이전까지)
+        } else if (LocalDateTime.now().isBefore(meetingDateTime)) {
+            extraCommission = new BigDecimal(0.7);
+        }
+        return extraCommission;
+    }
+
+    @Transactional
+    void cancelTicketByOrganizer(Ticket ticket) {
+        log.info("-----------주최자 식사권 취소");
+
+        // 낙찰자에게 전체 환불 & 주최자에게는 최소 입찰 금액 반환X
+        log.info("낙찰자 환불 받기 전 포인트 : {}", ticket.getWinner().getPoint());
+        ticket.getWinner().increasePoint(BigDecimal.valueOf(ticket.getAuction().getCurrentHighestBidAmount()));
+        log.info("낙찰자 환불 받은 후 포인트 : {}", ticket.getWinner().getPoint());
     }
 }

--- a/src/main/java/shootingstar/var/controller/TicketController.java
+++ b/src/main/java/shootingstar/var/controller/TicketController.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -128,5 +129,28 @@ public class TicketController {
         String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
         ticketService.reportTicket(reqDto, userUUID);
         return ResponseEntity.ok().body("식사권 신고 성공");
+    }
+
+    @Operation(summary = "식사권 취소하는 API", description = "낙찰자와 주최자 둘 다 사용")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "- 식사권의 낙찰자이거나 주최자일 때 : 식사권 취소 성공"),
+            @ApiResponse(responseCode = "404",
+                    description = "- 식사권 정보 조회 실패 : 6200",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "403",
+                    description = "- 로그인한 사용자가 경매의 낙찰자도 주최자도 아닐 때 : 0101",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "409",
+                    description =
+                                    "- 식사 시간 이후에 식사권 취소를 요청하는 경우 : 6302\n" +
+                                    "- 이미 취소된 식사권에 같은 요청을 보낼 경우 : 6303",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PatchMapping("/cancel/{ticketUUID}")
+    public ResponseEntity<String> cancelTicket(@PathVariable("ticketUUID") String ticketUUID, HttpServletRequest request) {
+        String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
+        ticketService.cancelTicket(ticketUUID, userUUID);
+        return ResponseEntity.ok().body("식사권 취소 성공");
     }
 }

--- a/src/main/java/shootingstar/var/dto/req/UserProfileDto.java
+++ b/src/main/java/shootingstar/var/dto/req/UserProfileDto.java
@@ -1,5 +1,6 @@
 package shootingstar.var.dto.req;
 
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import shootingstar.var.entity.UserType;
@@ -12,7 +13,7 @@ public class UserProfileDto {
     private String nickname;
     private String profileImgUrl;
     private Long donation_price;
-    private Long point;
+    private BigDecimal point;
     private LocalDateTime subscribe;
     private UserType user_type;
 }

--- a/src/main/java/shootingstar/var/dto/res/DetailTicketResDto.java
+++ b/src/main/java/shootingstar/var/dto/res/DetailTicketResDto.java
@@ -1,5 +1,7 @@
 package shootingstar.var.dto.res;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +13,7 @@ public class DetailTicketResDto {
     private String organizerNickname;
     private String winnerNickname;
     private Long winningBid;
-    private Double donation;
+    private BigDecimal donation;
     private String meetingInfoText;
     private String meetingPromiseText;
     private boolean winnerIsPushed;
@@ -19,14 +21,14 @@ public class DetailTicketResDto {
 
     @Builder
     public DetailTicketResDto(LocalDateTime meetingDate, String meetingLocation, String organizerNickname,
-                              String winnerNickname, Long winningBid, Double donation, String meetingInfoText,
+                              String winnerNickname, Long winningBid, BigDecimal donation, String meetingInfoText,
                               String meetingPromiseText, boolean winnerIsPushed, boolean organizerIsPushed) {
         this.meetingDate = meetingDate;
         this.meetingLocation = meetingLocation;
         this.organizerNickname = organizerNickname;
         this.winnerNickname = winnerNickname;
         this.winningBid = winningBid;
-        this.donation = donation;
+        this.donation = donation.setScale(2, RoundingMode.HALF_UP);
         this.meetingInfoText = meetingInfoText;
         this.meetingPromiseText = meetingPromiseText;
         this.winnerIsPushed = winnerIsPushed;

--- a/src/main/java/shootingstar/var/entity/Ticket.java
+++ b/src/main/java/shootingstar/var/entity/Ticket.java
@@ -57,6 +57,10 @@ public class Ticket extends BaseTimeEntity {
         this.organizerIsPushed = false;
     }
 
+    public void changeTicketIsOpened(boolean ticketIsOpened) {
+        this.ticketIsOpened = ticketIsOpened;
+    }
+
     public void changeWinnerIsPushed(boolean winnerIsPushed) {
         this.winnerIsPushed = winnerIsPushed;
     }

--- a/src/main/java/shootingstar/var/entity/User.java
+++ b/src/main/java/shootingstar/var/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,7 +48,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserType userType;
 
-    private Long point;
+    @Column(precision = 10, scale = 2)
+    private BigDecimal point;
 
     private Long donationPrice;
 
@@ -73,7 +75,7 @@ public class User extends BaseTimeEntity {
         this.email = email;
         this.profileImgUrl = profileImgUrl;
         this.userType = userType;
-        this.point = 0L;
+        this.point = new BigDecimal(0);
         this.donationPrice = 0L;
         this.rating = null;
         this.subscribe = null;
@@ -82,12 +84,12 @@ public class User extends BaseTimeEntity {
         this.withdrawnTime = null;
     }
 
-    public void increasePoint(long point) {
-        this.point += point;
+    public void increasePoint(BigDecimal point) {
+        this.point = this.point.add(point);
     }
 
-    public void decreasePoint(long point) {
-        this.point -= point;
+    public void decreasePoint(BigDecimal point) {
+        this.point = this.point.subtract(point);
     }
 
     public void withdrawn() {

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -82,6 +82,8 @@ public enum ErrorCode {
 
     TICKET_MEETING_TIME_CONFLICT(CONFLICT, "6300", "이미 처리된 식사권 만남 시간입니다."),
     TICKET_REPORT_CONFLICT(CONFLICT, "6301", "이미 신고된 식사권입니다."),
+    TICKET_CANCEL_CONFLICT(CONFLICT, "6302", "식사 시간이 지난 후에는 취소가 불가능합니다."),
+    ALREADY_TICKET_CANCEL_CONFLICT(CONFLICT, "6303", "이미 취소된 식사권입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
- API 명세에 낙찰자와 주최자 식사권 취소 API가 나누어져 있었는데 하나로 통합하고 API 경로도 수정
- AuctionService에서 최소 입찰 금액 10000만원 단위 아니면 에러 처리

### 식사권 취소하는 로직
**1. 낙찰자가 취소**
- 로그인한 사용자가 경매의 낙찰자도 주최자도 아닐 때, 에러 처리
- 현재 시간이 식사 날짜 시간을 지났을 때, 에러 처리
- 식사권이 닫혔을 때, 에러 처리
- 환불 정책에 따라 수수료 계산 후 주최자에게 수수료 포인트 제공
- 환불 정책에 따라 수수료 계산 후 최고 입찰 금액에서 수수료를 제외한 금액을 낙찰자에게 반환
- 주최자에게 최소 입찰 금액 반환(보증금)
- 채팅방 닫기
- 식사권 오픈여부 false로 변경

**2. 주최자가 취소**
- 로그인한 사용자가 경매의 낙찰자도 주최자도 아닐 때, 에러 처리
- 현재 시간이 식사 날짜 시간을 지났을 때, 에러 처리
- 식사권이 닫혔을 때, 에러 처리
- 낙찰자에게 전체 환불 & 주최자에게는 최소 입찰 금액 반환X
- 채팅방 닫기
- 식사권 오픈여부 false로 변경

### User의 point 필드 타입을 Long에서 BigDecimal로 변경
=> double은 부동 소수점 연산을 수행할 때 불가피하게 발생하는 오차가 있어서 정밀한 소수점 연산이 필요할 때 사용하는 BigDecimal로 변경
=> 현재 로직 상 Long 타입이어도 문제될 부분은 없으나 추후에 수수료 관련 정책이 바뀌었을 때 유지보수를 고려하여 BigDecimal로 결정

- UserProfileDto에서 point 타입 변경되었고, PaymentService에서 2군데 변경되었으니 확인 바랍니다!
- 채팅방 관련 로직은 추후에 추가할 예정입니다.