### PR TITLE
Feat: 리뷰 작성 API

### DIFF
--- a/src/main/java/shootingstar/var/controller/TicketController.java
+++ b/src/main/java/shootingstar/var/controller/TicketController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shootingstar.var.Service.TicketService;
 import shootingstar.var.dto.req.MeetingTimeSaveReqDto;
+import shootingstar.var.dto.req.ReviewSaveReqDto;
 import shootingstar.var.dto.req.TicketReportReqDto;
 import shootingstar.var.dto.res.DetailTicketResDto;
 import shootingstar.var.dto.res.MeetingTimeResDto;
@@ -152,5 +153,33 @@ public class TicketController {
         String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
         ticketService.cancelTicket(ticketUUID, userUUID);
         return ResponseEntity.ok().body("식사권 취소 성공");
+    }
+
+    @Operation(summary = "식사권 리뷰 작성 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "식사권 리뷰 작성 성공"),
+            @ApiResponse(responseCode = "400",
+                    description =
+                                    "- 잘못된 형식의 식사권 고유번호 입력 시 : 6001\n" +
+                                    "- 잘못된 형식의 리뷰 내용 입력 시 : 6005\n" +
+                                    "- 잘못된 형식의 리뷰 점수 입력 시 : 6006\n" +
+                                    "- 만남 시간 + 2시간 전에 리뷰 작성 시 : 6007",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404",
+                    description = "- 식사권 정보 조회 실패 : 6200",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "409",
+                    description = "- 해당 식사권에 대한 리뷰를 작성한 적이 있을 때 : 6304",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "403",
+                    description = "- 로그인한 사용자가 식사권의 낙찰자도 주최자도 아닐 때 : 0101",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping("/review")
+    public ResponseEntity<String> saveReview(@Valid @RequestBody ReviewSaveReqDto reqDto, HttpServletRequest request) {
+        String userUUID = jwtTokenProvider.getUserUUIDByRequest(request);
+        ticketService.saveReview(reqDto, userUUID);
+        return ResponseEntity.ok().body("식사권 리뷰 작성 성공");
     }
 }

--- a/src/main/java/shootingstar/var/dto/req/ReviewSaveReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/ReviewSaveReqDto.java
@@ -1,0 +1,20 @@
+package shootingstar.var.dto.req;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ReviewSaveReqDto {
+    @NotNull
+    private Long ticketId;
+
+    @NotBlank
+    private String reviewContent;
+
+    @Min(value = 1)
+    @Max(value = 5)
+    private double reviewRating;
+}

--- a/src/main/java/shootingstar/var/entity/Review.java
+++ b/src/main/java/shootingstar/var/entity/Review.java
@@ -1,7 +1,8 @@
 package shootingstar.var.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,41 +12,41 @@ import shootingstar.var.entity.ticket.Ticket;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Review {
+public class Review extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewId;
 
-    @NotNull
     private String reviewUUID;
 
-    private String reviewContent;
-    private Double reviewRating;
-
-    private Boolean isShowed;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
-    private User writerId;
+    private User writer;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id")
-    private User receiverId;
+    private User receiver;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id")
-    private Ticket ticketId;
+    private Ticket ticket;
 
+    @NotBlank
+    private String reviewContent;
 
+    private double reviewRating;
 
-    public Review(User writerId, User receiverId, String reviewContent,
-                  double reviewRating, Ticket ticketId, Boolean isShowed){
+    private boolean isShowed;
+
+    @Builder
+    public Review(User writer, User receiver, Ticket ticket, String reviewContent,
+                  double reviewRating) {
         this.reviewUUID = UUID.randomUUID().toString();
-        this.receiverId = receiverId;
-        this.writerId = writerId;
+        this.writer = writer;
+        this.receiver = receiver;
+        this.ticket = ticket;
         this.reviewContent = reviewContent;
         this.reviewRating = reviewRating;
-        this.ticketId = ticketId;
-        this.isShowed =isShowed;
+        this.isShowed = true;
     }
 }

--- a/src/main/java/shootingstar/var/entity/ticket/Ticket.java
+++ b/src/main/java/shootingstar/var/entity/ticket/Ticket.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shootingstar.var.entity.Auction;
 import shootingstar.var.entity.BaseTimeEntity;
+import shootingstar.var.entity.Review;
 import shootingstar.var.entity.User;
 
 @Entity
@@ -47,6 +48,9 @@ public class Ticket extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "ticket")
     private List<TicketMeetingTime> ticketMeetingTimes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ticket")
+    private List<Review> reviews = new ArrayList<>();
 
     @Builder
     public Ticket(Auction auction, User winner, User organizer) {

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
     INCORRECT_FORMAT_START_MEETING_TIME(BAD_REQUEST, "6002", "잘못된 형식의 만남 시작 시간입니다."),
     INCORRECT_FORMAT_TICKET_REPORT_CONTENT(BAD_REQUEST, "6003", "잘못된 형식의 식사권 신고 내용입니다."),
     INCORRECT_FORMAT_TICKET_REPORT_EVIDENCE_URL(BAD_REQUEST, "6004", "잘못된 형식의 식사권 신고 증거 URL입니다."),
+    INCORRECT_FORMAT_REVIEW_CONTENT(BAD_REQUEST, "6005", "잘못된 형식의 리뷰 내용입니다."),
+    INCORRECT_FORMAT_REVIEW_RATING(BAD_REQUEST, "6006", "잘못된 형식의 리뷰 점수입니다."),
+    MEETING_TIME_NOT_PASSED(BAD_REQUEST, "6007", "만남이 끝나기 전에 리뷰 작성을 할 수 없습니다."),
 
     TICKET_NOT_FOUND(NOT_FOUND, "6200", "존재하지 않는 식사권입니다."),
     TICKET_MEETING_TIME_NOT_FOUND(NOT_FOUND, "6201", "존재하지 않는 만남 시작 시간입니다."),
@@ -84,6 +87,7 @@ public enum ErrorCode {
     TICKET_REPORT_CONFLICT(CONFLICT, "6301", "이미 신고된 식사권입니다."),
     TICKET_CANCEL_CONFLICT(CONFLICT, "6302", "식사 시간이 지난 후에는 취소가 불가능합니다."),
     ALREADY_TICKET_CANCEL_CONFLICT(CONFLICT, "6303", "이미 취소된 식사권입니다."),
+    REVIEW_CONFLICT(CONFLICT, "6304", "해당 식사권에 대한 리뷰를 작성한 적이 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/shootingstar/var/repository/Review/ReviewRepositoryImpl.java
+++ b/src/main/java/shootingstar/var/repository/Review/ReviewRepositoryImpl.java
@@ -27,10 +27,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
                 return queryFactory
                 .select(new QUserReceiveReviewDto(
                         review.reviewUUID,
-                        review.ticketId.ticketUUID,
+                        review.ticket.ticketUUID,
                         review.reviewContent,
                         review.reviewRating,
-                        review.writerId.userUUID
+                        review.writer.userUUID
                 ))
                 .from(review)
                 .where(userEqReceiver(userUUID))
@@ -42,13 +42,13 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         List<UserReceiveReviewDto> content = queryFactory
                 .select(new QUserReceiveReviewDto(
                         review.reviewUUID,
-                        review.ticketId.ticketUUID,
+                        review.ticket.ticketUUID,
                         review.reviewContent,
                         review.reviewRating,
-                        review.writerId.userUUID
+                        review.writer.userUUID
                 ))
                 .from(review)
-                .where(userEqReceiver(userUUID), review.receiverId.isWithdrawn.eq(false))
+                .where(userEqReceiver(userUUID), review.receiver.isWithdrawn.eq(false))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(review.reviewId.desc())
@@ -57,7 +57,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         JPAQuery<Long> countQuery = queryFactory
                 .select(review.count())
                 .from(review)
-                .where(userEqReceiver(userUUID), review.receiverId.isWithdrawn.eq(false));
+                .where(userEqReceiver(userUUID), review.receiver.isWithdrawn.eq(false));
 
         return PageableExecutionUtils.getPage(content,pageable,countQuery::fetchOne);
     }
@@ -66,10 +66,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         return queryFactory
                 .select(new QUserSendReviewDto(
                         review.reviewUUID,
-                        review.ticketId.ticketUUID,
+                        review.ticket.ticketUUID,
                         review.reviewContent,
                         review.reviewRating,
-                        review.receiverId.userUUID
+                        review.receiver.userUUID
                 ))
                 .from(review)
                 .where(userEqWriter(userUUID))
@@ -81,13 +81,13 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         List<UserSendReviewDto> content = queryFactory
                 .select(new QUserSendReviewDto(
                         review.reviewUUID,
-                        review.ticketId.ticketUUID,
+                        review.ticket.ticketUUID,
                         review.reviewContent,
                         review.reviewRating,
-                        review.receiverId.userUUID
+                        review.receiver.userUUID
                 ))
                 .from(review)
-                .where(userEqWriter(userUUID), review.writerId.isWithdrawn.eq(false))
+                .where(userEqWriter(userUUID), review.writer.isWithdrawn.eq(false))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(review.reviewId.desc())
@@ -96,17 +96,17 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         JPAQuery<Long> countQuery = queryFactory
                 .select(review.count())
                 .from(review)
-                .where(userEqReceiver(userUUID), review.writerId.isWithdrawn.eq(true));
+                .where(userEqReceiver(userUUID), review.writer.isWithdrawn.eq(true));
 
         return PageableExecutionUtils.getPage(content,pageable,countQuery::fetchOne);
     }
 
     private BooleanExpression userEqReceiver(String userUUID){
-        return userUUID !=null ? review.receiverId.userUUID.eq(userUUID) : null;
+        return userUUID !=null ? review.receiver.userUUID.eq(userUUID) : null;
     }
 
     private BooleanExpression userEqWriter(String userUUID){
-        return userUUID != null ? review.writerId.userUUID.eq(userUUID) : null;
+        return userUUID != null ? review.writer.userUUID.eq(userUUID) : null;
     }
 
 }


### PR DESCRIPTION
### 리뷰 작성 로직
- 로그인한 사용자가 식사권의 낙찰자도 주최자도 아닐 경우, 에러 처리
- 해당 식사권에 대한 리뷰를 작성한 적이 있는 경우, 에러 처리
- 현재 시간이 식사 날짜 시간 + 2시간 전인 경우, 에러 처리(우리 식사 시간이 만남 시간 + 2시간 이라서)
- 로그인한 사용자가 낙찰자인지 주최자인지 구분 후 알맞게 Review 인스턴스 생성해서 저장

### 추가사항
- 리뷰 작성 기한을 따로 두지 않았음(수요일 회의 결과)
- Review 엔티티 필드명 수정
- 현재 별점은 (1 ~ 5까지 double 타입으로 입력 가능)