### PR TITLE
Feature/admin login

### DIFF
--- a/src/main/java/shootingstar/var/Service/AdminService.java
+++ b/src/main/java/shootingstar/var/Service/AdminService.java
@@ -1,0 +1,43 @@
+package shootingstar.var.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import shootingstar.var.entity.Admin;
+import shootingstar.var.jwt.JwtTokenProvider;
+import shootingstar.var.jwt.TokenInfo;
+import shootingstar.var.repository.admin.AdminRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider tokenProvider;
+
+    @Value("${admin-secret-signup-key}")
+    private String adminSignupSecretKey;
+
+    public void signup(String id, String password, String secretKey) {
+        if (!secretKey.equals(adminSignupSecretKey)) {
+            throw new RuntimeException("회원가입 실패 잘못된 인증 키");
+        }
+        if (adminRepository.existsByAdminLoginId(id)) {
+            throw new RuntimeException("해당 id로 가입 불가능");
+        }
+        String encodePassword = passwordEncoder.encode(password); // 패스워드 암호화
+        Admin admin = new Admin(id, encodePassword);
+        adminRepository.save(admin);
+    }
+
+    public TokenInfo login(String id, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        return tokenProvider.generateToken(authentication);
+    }
+}

--- a/src/main/java/shootingstar/var/config/SecurityConfig.java
+++ b/src/main/java/shootingstar/var/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -55,7 +57,9 @@ public class SecurityConfig {
                                         "/api/all/**",
                                         "/api/auth/**",
                                         "/v3/api-docs/**", // swagger 설정
-                                        "/swagger-ui/**" // swagger 설정
+                                        "/swagger-ui/**", // swagger 설정
+                                        "/api/admin/signup",
+                                        "/api/admin/login"
                                 ).permitAll()
 
                                 .requestMatchers(
@@ -70,6 +74,11 @@ public class SecurityConfig {
                                         "/api/vip/**"
                                 ).hasRole("VIP")
 
+                                .requestMatchers(
+                                        "/api/admin/test"
+                                ).hasRole("ADMIN")
+
+
                                 .anyRequest().authenticated() // 정의한 엔드 포인트를 제외한 모든 요청은 인증이 필요함
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
@@ -83,6 +92,11 @@ public class SecurityConfig {
 //                                .userService(oAuth2UserService)))
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/shootingstar/var/controller/AdminController.java
+++ b/src/main/java/shootingstar/var/controller/AdminController.java
@@ -1,0 +1,35 @@
+package shootingstar.var.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import shootingstar.var.Service.AdminService;
+import shootingstar.var.dto.req.AdminSignupReqDto;
+import shootingstar.var.jwt.TokenInfo;
+import shootingstar.var.jwt.TokenProperty;
+import shootingstar.var.util.TokenUtil;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+    private final AdminService adminService;
+    private final TokenProperty tokenProperty;
+
+    @PostMapping("/signup")
+    public void signup(@RequestBody AdminSignupReqDto reqDto) {
+        adminService.signup(reqDto.getLoginId(), reqDto.getPassword(), reqDto.getSecretKey());
+    }
+
+    @PostMapping("/login")
+    public void login(@RequestBody AdminSignupReqDto reqDto, HttpServletResponse response) {
+        TokenInfo tokenInfo = adminService.login(reqDto.getLoginId(), reqDto.getPassword());
+        TokenUtil.addHeader(response, tokenInfo.getAccessToken());
+        TokenUtil.updateCookie(response, tokenInfo.getRefreshToken(), tokenProperty.getREFRESH_EXPIRE());
+    }
+
+    @GetMapping("/test")
+    public String test() {
+        return "관리자 접근 성공";
+    }
+}

--- a/src/main/java/shootingstar/var/controller/AdminController.java
+++ b/src/main/java/shootingstar/var/controller/AdminController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import shootingstar.var.Service.AdminService;
+import shootingstar.var.dto.req.AdminLoginReqDto;
 import shootingstar.var.dto.req.AdminSignupReqDto;
 import shootingstar.var.jwt.TokenInfo;
 import shootingstar.var.jwt.TokenProperty;
@@ -22,7 +23,7 @@ public class AdminController {
     }
 
     @PostMapping("/login")
-    public void login(@RequestBody AdminSignupReqDto reqDto, HttpServletResponse response) {
+    public void login(@RequestBody AdminLoginReqDto reqDto, HttpServletResponse response) {
         TokenInfo tokenInfo = adminService.login(reqDto.getLoginId(), reqDto.getPassword());
         TokenUtil.addHeader(response, tokenInfo.getAccessToken());
         TokenUtil.updateCookie(response, tokenInfo.getRefreshToken(), tokenProperty.getREFRESH_EXPIRE());

--- a/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
@@ -1,0 +1,9 @@
+package shootingstar.var.dto.req;
+
+import lombok.Data;
+
+@Data
+public class AdminLoginReqDto {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
@@ -1,0 +1,10 @@
+package shootingstar.var.dto.req;
+
+import lombok.Data;
+
+@Data
+public class AdminSignupReqDto {
+    private String loginId;
+    private String password;
+    private String secretKey;
+}

--- a/src/main/java/shootingstar/var/entity/Admin.java
+++ b/src/main/java/shootingstar/var/entity/Admin.java
@@ -1,0 +1,73 @@
+package shootingstar.var.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import shootingstar.var.enums.type.UserType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin extends BaseTimeEntity implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long adminId;
+    private String adminUUID;
+    @NotBlank
+    private String adminLoginId;
+    @NotBlank
+    private String password;
+    @Enumerated(EnumType.STRING)
+    private UserType role;
+
+    public Admin(String adminLoginId, String password) {
+        this.adminUUID = UUID.randomUUID().toString();
+        this.adminLoginId = adminLoginId;
+        this.password = password;
+        this.role = UserType.ROLE_ADMIN;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ADMIN"));
+    }
+
+    @Override
+    public String getUsername() {
+        return adminUUID;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/shootingstar/var/jwt/CustomUserDetailService.java
+++ b/src/main/java/shootingstar/var/jwt/CustomUserDetailService.java
@@ -1,0 +1,34 @@
+package shootingstar.var.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import shootingstar.var.entity.Admin;
+import shootingstar.var.exception.CustomException;
+import shootingstar.var.exception.ErrorCode;
+import shootingstar.var.repository.admin.AdminRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+    private final AdminRepository adminRepository;
+
+    // 사용자 이름으로 사용자 조회
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        return adminRepository.findByAdminLoginId(loginId)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 해당하는 User 의 데이터가 존재한다면 UserDetails 객체로 만들어서 리턴
+    private UserDetails createUserDetails(Admin admin) {
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(admin.getUsername())
+                .password(admin.getPassword())
+                .roles("ADMIN")
+                .build();
+    }
+}

--- a/src/main/java/shootingstar/var/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/shootingstar/var/jwt/JwtAuthenticationFilter.java
@@ -35,10 +35,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         String requestURI = httpRequest.getRequestURI();
         log.info("JwtAuthenticationFilter requestURI :  {}, addr : {}", requestURI, httpRequest.getRemoteAddr());
         /*
-          /api/auth/refresh, /api/auth/logout, /error 엔드 포인트는 JWT 검증을 하지 않는다
-          /api/auth/refresh, /api/auth/logout 엔드 포인트는 Controller, Service 에서 별도의 검증을 한다.
+          /error 엔드 포인트는 JWT 검증을 하지 않는다
          */
-        if (requestURI.equals("/api/auth/refresh") || requestURI.equals("/api/auth/logout") || requestURI.equals("/error")) {
+        if (requestURI.equals("/error")) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/shootingstar/var/jwt/JwtTokenProvider.java
+++ b/src/main/java/shootingstar/var/jwt/JwtTokenProvider.java
@@ -16,9 +16,11 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import shootingstar.var.entity.Admin;
 import shootingstar.var.entity.User;
 import shootingstar.var.exception.CustomException;
 import shootingstar.var.exception.ErrorCode;
+import shootingstar.var.repository.admin.AdminRepository;
 import shootingstar.var.repository.user.UserRepository;
 import shootingstar.var.util.JwtRedisUtil;
 import shootingstar.var.util.LoginListRedisUtil;
@@ -44,17 +46,19 @@ public class JwtTokenProvider {
     private final JwtRedisUtil jwtRedisUtil;
     private final LoginListRedisUtil loginListRedisUtil;
     private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
     public JwtTokenProvider(@Value("${jwt.secret-access}") String accessSecretKey,
                             @Value("${jwt.secret-refresh}") String refreshSecretKey,
-                            TokenProperty tokenProperty, UserRepository userRepository, JwtRedisUtil jwtRedisUtil, LoginListRedisUtil loginListRedisUtil) {
+                            TokenProperty tokenProperty, UserRepository userRepository, JwtRedisUtil jwtRedisUtil, LoginListRedisUtil loginListRedisUtil, AdminRepository adminRepository) {
         this.tokenProperty = tokenProperty;
         this.jwtRedisUtil = jwtRedisUtil;
         this.loginListRedisUtil = loginListRedisUtil;
         this.userRepository = userRepository;
+        this.adminRepository = adminRepository;
         byte[] accessKeyBytes = Decoders.BASE64.decode(accessSecretKey);
         byte[] refreshKeyBytes = Decoders.BASE64.decode(refreshSecretKey);
 
@@ -167,11 +171,18 @@ public class JwtTokenProvider {
 
         String subject = claims.getSubject();
 
+        String authority;
         Optional<User> optionalUser = userRepository.findByUserUUID(subject);
         if (optionalUser.isEmpty()) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            Optional<Admin> optionalAdmin = adminRepository.findByAdminUUID(subject);
+            if (optionalAdmin.isEmpty()) {
+                throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            } else {
+                authority = optionalAdmin.get().getRole().toString();
+            }
+        } else {
+            authority = optionalUser.get().getUserType().toString();
         }
-        String authority = optionalUser.get().getUserType().toString();
 
         List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList(authority);
 

--- a/src/main/java/shootingstar/var/repository/admin/AdminRepository.java
+++ b/src/main/java/shootingstar/var/repository/admin/AdminRepository.java
@@ -1,0 +1,13 @@
+package shootingstar.var.repository.admin;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shootingstar.var.entity.Admin;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByAdminLoginId(String loginId);
+    Optional<Admin> findByAdminUUID(String uuid);
+
+    boolean existsByAdminLoginId(String loginId);
+}


### PR DESCRIPTION
## 관리자 회원가입
회원가입은 아이디, 패스워드, 시크릿 키를 통해 이루어집니다.
아이디는 중복검사가 이루어지며 시크릿 키는 미리 지정한 값을 yml에서 관리합니다.
데이터 베이스에 저장시 패스워드는 암호화되어 저장됩니다.

## 관리자 로그인
로그인은 아이디 패스워드를 통해 이루어집니다.
전달받은 패스워드를 복호화해 검증이 이루어지며
성공적으로 로그인시 액세스 토큰과 리프레시 토큰을 반환합니다.
액새스 토큰은 admin 권한 정보를 가집니다.

### Admin Entity 를 생성했습니다.
   - 인증 객체 생성을 위해 UserDetail을 implements 합니다.

### CustomUserDetailService를 생성했습니다.
   - 아이디와 비밀번호를 통해 인증 객체를 생성하는 서비스입니다.

### SecurityConfig 에 엔드포인트를 추가하였습니다.
   - admin 회원가입, 로그인 엔드포인트를 인증없이 통과시킵니다.
   - /api/admin/test 엔드포인트는 admin 권한을 가진 사용자만 통과시킵니다.
   - 비밀번호 암호화를 위해 passwordEncoder를 빈에 추가하였습니다.

### JwtAuthenticationFilter 필요없는 코드를 수정했습니다.

### JwtTokenProvider 리프레시 토큰 검증에 관리자 토큰을 위한 코드를 추가하였습니다.

### AdminController를 생성했습니다.
   - 회원가입, 로그인, 테스트 엔드포인트를 추가하였습니다.

### AdminSignupReqDto를 생성했습니다.
   - 아이디, 비밀번호, 시크릿 키 를 전달받습니다.

### AdminLoginReqDto를 생성했습니다.
   - 아이디, 비밀번호를 전달받습니다.

### AdminService를 생성했습니다.
   - 회원가입 로직을 구현하였습니다.
   - 로그인 로직을 구현하였습니다.

### AdminRepository를 생성했습니다.