### PR TITLE
Feat: 만남 시간으로부터 3일이 지난 식사권 완료 처리

### DIFF
--- a/src/main/java/shootingstar/var/Service/AuctionService.java
+++ b/src/main/java/shootingstar/var/Service/AuctionService.java
@@ -1,7 +1,5 @@
 package shootingstar.var.Service;
 
-import jakarta.persistence.OptimisticLockException;
-import java.awt.Point;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -25,11 +23,10 @@ import shootingstar.var.entity.ScheduledTask;
 import shootingstar.var.enums.type.PointOriginType;
 import shootingstar.var.enums.type.TaskType;
 import shootingstar.var.entity.User;
-import shootingstar.var.enums.type.TransactionType;
 import shootingstar.var.enums.type.UserType;
 import shootingstar.var.exception.CustomException;
 import shootingstar.var.exception.ErrorCode;
-import shootingstar.var.quartz.TicketCreationJob;
+import shootingstar.var.scheduling.quartz.TicketCreationJob;
 import shootingstar.var.repository.AuctionRepository;
 import shootingstar.var.repository.PointLogRepository;
 import shootingstar.var.repository.ScheduledTaskRepository;

--- a/src/main/java/shootingstar/var/Service/SchedulerService.java
+++ b/src/main/java/shootingstar/var/Service/SchedulerService.java
@@ -1,12 +1,15 @@
 package shootingstar.var.Service;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shootingstar.var.entity.Auction;
 import shootingstar.var.entity.PointLog;
+import shootingstar.var.entity.ticket.TicketMeetingTime;
 import shootingstar.var.enums.type.AuctionType;
 import shootingstar.var.entity.ScheduledTask;
 import shootingstar.var.enums.type.PointOriginType;
@@ -19,6 +22,7 @@ import shootingstar.var.exception.ErrorCode;
 import shootingstar.var.repository.AuctionRepository;
 import shootingstar.var.repository.PointLogRepository;
 import shootingstar.var.repository.ScheduledTaskRepository;
+import shootingstar.var.repository.ticket.TicketMeetingTimeRepository;
 import shootingstar.var.repository.ticket.TicketRepository;
 import shootingstar.var.repository.user.UserRepository;
 
@@ -79,5 +83,55 @@ public class SchedulerService {
         ScheduledTask task = scheduledTaskRepository.findById(scheduledTaskId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
         task.changeTaskType(TaskType.COMPLETE);
+    }
+
+    @Transactional
+    public void completeTicket() {
+        log.info("식사권 완료 로직 실행, 현재 시간 : {}", LocalDateTime.now());
+
+        List<Ticket> tickets = ticketRepository.findByTicketIsOpenedTrueAndWinnerIsPushedTrueAndOrganizerIsPushedTrue();
+        for (Ticket ticket : tickets) {
+            LocalDateTime meetingTime = calculateMeetingTime(ticket);
+
+            // 만남 시작 시간 이후 3일이 지나지 않았을 경우
+            if (meetingTime.plusDays(3).isAfter(LocalDateTime.now())) {
+                log.info("3일이 지나지 않음");
+                continue;
+            }
+
+            // 식사권이 신고된 경우
+            if (ticket.getReports().size() > 0) {
+                log.info("신고당한 식사권");
+                continue;
+            }
+
+            // 식사권 닫기
+            ticket.changeTicketIsOpened(false);
+
+            // 채팅방 닫기 => 추후 추가할 예정
+
+            // 포인트 정산
+            // 경매 주최자에게 70% 지급
+            User organizer = userRepository.findByUserUUIDWithPessimisticLock(ticket.getOrganizer().getUserUUID())
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+            BigDecimal point = BigDecimal.valueOf(ticket.getAuction().getCurrentHighestBidAmount()).multiply(new BigDecimal(0.7));
+            organizer.increasePoint(point);
+
+            PointLog pointLog = PointLog.createPointLogWithDeposit(organizer, PointOriginType.TICKET_COMPLETE, point);
+            pointLogRepository.save(pointLog);
+
+            // 기부금액에 5% 추가 => 추후 추가할 예정
+        }
+    }
+
+    public LocalDateTime calculateMeetingTime(Ticket ticket) {
+        LocalDateTime meetingTime;
+        List<TicketMeetingTime> ticketMeetingTimes = ticket.getTicketMeetingTimes();
+        if (ticketMeetingTimes.get(0).getStartMeetingTime().isAfter(ticketMeetingTimes.get(1).getStartMeetingTime())) {
+            meetingTime = ticketMeetingTimes.get(0).getStartMeetingTime();
+        } else {
+            meetingTime = ticketMeetingTimes.get(1).getStartMeetingTime();
+        }
+        return meetingTime;
     }
 }

--- a/src/main/java/shootingstar/var/VarApplication.java
+++ b/src/main/java/shootingstar/var/VarApplication.java
@@ -3,8 +3,10 @@ package shootingstar.var;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class VarApplication {
 

--- a/src/main/java/shootingstar/var/entity/ticket/Ticket.java
+++ b/src/main/java/shootingstar/var/entity/ticket/Ticket.java
@@ -52,6 +52,9 @@ public class Ticket extends BaseTimeEntity {
     @OneToMany(mappedBy = "ticket")
     private List<Review> reviews = new ArrayList<>();
 
+    @OneToMany(mappedBy = "ticket")
+    private List<TicketReport> reports = new ArrayList<>();
+
     @Builder
     public Ticket(Auction auction, User winner, User organizer) {
         this.ticketUUID = UUID.randomUUID().toString();

--- a/src/main/java/shootingstar/var/repository/ticket/TicketRepository.java
+++ b/src/main/java/shootingstar/var/repository/ticket/TicketRepository.java
@@ -1,9 +1,11 @@
 package shootingstar.var.repository.ticket;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shootingstar.var.entity.ticket.Ticket;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom {
     Optional<Ticket> findByTicketUUID(String ticketUUID);
+    List<Ticket> findByTicketIsOpenedTrueAndWinnerIsPushedTrueAndOrganizerIsPushedTrue();
 }

--- a/src/main/java/shootingstar/var/scheduling/ScheduledTasks.java
+++ b/src/main/java/shootingstar/var/scheduling/ScheduledTasks.java
@@ -1,0 +1,18 @@
+package shootingstar.var.scheduling;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import shootingstar.var.Service.SchedulerService;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledTasks {
+
+    private final SchedulerService schedulerService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void completeTicket() {
+        schedulerService.completeTicket();
+    }
+}

--- a/src/main/java/shootingstar/var/scheduling/quartz/SchedulerInitializer.java
+++ b/src/main/java/shootingstar/var/scheduling/quartz/SchedulerInitializer.java
@@ -1,4 +1,4 @@
-package shootingstar.var.quartz;
+package shootingstar.var.scheduling.quartz;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/main/java/shootingstar/var/scheduling/quartz/TicketCreationJob.java
+++ b/src/main/java/shootingstar/var/scheduling/quartz/TicketCreationJob.java
@@ -1,4 +1,4 @@
-package shootingstar.var.quartz;
+package shootingstar.var.scheduling.quartz;
 
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;


### PR DESCRIPTION
1. 매일 자정에 식사권 완료처리하는 스케줄링 추가
2. @Scheduled를 사용


### **식사권 완료 처리 로직**
- 식사권이 열려있으면서 낙찰자와 경매주최자 모두 만남 시간 버튼을 누른 티켓들 조회
- 만남 시작 시간 이후 3일이 지나지 않은 티켓은 제외
- 식사권이 신고된 내역이 있는 티켓 제외
- 식사권의 ticketIsOpened => false로 처리
- 채팅방 닫기 => 추후 추가할 예정
- 경매주최자에게 포인트 정산(경매 주최자에게 최고입찰금액의 70% 포인트 지급 & 포인트 로그 저장)
- 기부금액에 최고입찰금액의 5% 포인트 추가 => 추후 추가할 예정