### PR TITLE
Refactoring/admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build/
 
 **/src/main/resources/ssl/
 
+**/src/test/java/shootingstar/var/Service/DummyDataTest.java
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/shootingstar/var/Service/AdminService.java
+++ b/src/main/java/shootingstar/var/Service/AdminService.java
@@ -39,15 +39,18 @@ public class AdminService {
     @Value("${admin-secret-signup-key}")
     private String adminSignupSecretKey;
 
-    public void signup(String id, String password, String secretKey) {
+    public void signup(String id, String password, String nickname, String secretKey) {
         if (!secretKey.equals(adminSignupSecretKey)) {
             throw new RuntimeException("회원가입 실패 잘못된 인증 키");
         }
         if (adminRepository.existsByAdminLoginId(id)) {
             throw new RuntimeException("해당 id로 가입 불가능");
         }
+        if (adminRepository.existsByNickname(nickname)) {
+            throw new RuntimeException("해당 닉네임으로 가입 불가능");
+        }
         String encodePassword = passwordEncoder.encode(password); // 패스워드 암호화
-        Admin admin = new Admin(id, encodePassword);
+        Admin admin = new Admin(id, encodePassword, nickname);
         adminRepository.save(admin);
     }
 

--- a/src/main/java/shootingstar/var/Service/AdminService.java
+++ b/src/main/java/shootingstar/var/Service/AdminService.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import shootingstar.var.dto.res.*;
 import shootingstar.var.entity.*;
+import shootingstar.var.exception.CustomException;
+import shootingstar.var.exception.ErrorCode;
 import shootingstar.var.jwt.JwtTokenProvider;
 import shootingstar.var.jwt.TokenInfo;
 import shootingstar.var.repository.BanRepository;
@@ -41,13 +43,13 @@ public class AdminService {
 
     public void signup(String id, String password, String nickname, String secretKey) {
         if (!secretKey.equals(adminSignupSecretKey)) {
-            throw new RuntimeException("회원가입 실패 잘못된 인증 키");
+            throw new CustomException(ErrorCode.INCORRECT_VALUE_ADMIN_SECRET_KEY);
         }
         if (adminRepository.existsByAdminLoginId(id)) {
-            throw new RuntimeException("해당 id로 가입 불가능");
+            throw new CustomException(ErrorCode.DUPLICATE_ADMIN_ID);
         }
         if (adminRepository.existsByNickname(nickname)) {
-            throw new RuntimeException("해당 닉네임으로 가입 불가능");
+            throw new CustomException(ErrorCode.DUPLICATE_ADMIN_NICKNAME);
         }
         String encodePassword = passwordEncoder.encode(password); // 패스워드 암호화
         Admin admin = new Admin(id, encodePassword, nickname);
@@ -55,8 +57,13 @@ public class AdminService {
     }
 
     public TokenInfo login(String id, String password) {
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        Authentication authentication;
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
+            authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ADMIN_LOGIN_FAILED);
+        }
         return tokenProvider.generateToken(authentication);
     }
 

--- a/src/main/java/shootingstar/var/config/SecurityConfig.java
+++ b/src/main/java/shootingstar/var/config/SecurityConfig.java
@@ -58,8 +58,8 @@ public class SecurityConfig {
                                         "/api/auth/**",
                                         "/v3/api-docs/**", // swagger 설정
                                         "/swagger-ui/**", // swagger 설정
-                                        "/api/admin/signup",
-                                        "/api/admin/login",
+                                        "/api/lookAtMe/signup",
+                                        "/api/lookAtMe/login",
                                         "/ws/chat"
                                 ).permitAll()
 
@@ -77,7 +77,7 @@ public class SecurityConfig {
                                 ).hasRole("VIP")
 
                                 .requestMatchers(
-                                        "/api/admin/test"
+                                        "/api/lookAtMe/test"
                                 ).hasRole("ADMIN")
 
 

--- a/src/main/java/shootingstar/var/controller/AdminController.java
+++ b/src/main/java/shootingstar/var/controller/AdminController.java
@@ -29,13 +29,13 @@ public class AdminController {
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody AdminSignupReqDto reqDto) {
-        adminService.signup(reqDto.getLoginId(), reqDto.getPassword(), reqDto.getNickname(), reqDto.getSecretKey());
+        adminService.signup(reqDto.getAdminLoginId(), reqDto.getAdminPassword(), reqDto.getAdminNickname(), reqDto.getAdminSecretKey());
         return ResponseEntity.ok().body("회원가입에 성공하였습니다.");
     }
 
     @PostMapping("/login")
     public ResponseEntity<String> login(@Valid @RequestBody AdminLoginReqDto reqDto, HttpServletResponse response) {
-        TokenInfo tokenInfo = adminService.login(reqDto.getLoginId(), reqDto.getPassword());
+        TokenInfo tokenInfo = adminService.login(reqDto.getAdminLoginId(), reqDto.getAdminPassword());
         TokenUtil.addHeader(response, tokenInfo.getAccessToken());
         TokenUtil.updateCookie(response, tokenInfo.getRefreshToken(), tokenProperty.getREFRESH_EXPIRE());
         return ResponseEntity.ok().body("로그인에 성공하였습니다.");

--- a/src/main/java/shootingstar/var/controller/AdminController.java
+++ b/src/main/java/shootingstar/var/controller/AdminController.java
@@ -3,11 +3,13 @@ package shootingstar.var.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import shootingstar.var.Service.AdminService;
 import shootingstar.var.dto.req.AdminLoginReqDto;
@@ -17,23 +19,26 @@ import shootingstar.var.jwt.TokenInfo;
 import shootingstar.var.jwt.TokenProperty;
 import shootingstar.var.util.TokenUtil;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin")
+@RequestMapping("/api/lookAtMe")
 public class AdminController {
     private final AdminService adminService;
     private final TokenProperty tokenProperty;
 
     @PostMapping("/signup")
-    public void signup(@RequestBody AdminSignupReqDto reqDto) {
-        adminService.signup(reqDto.getLoginId(), reqDto.getPassword(), reqDto.getSecretKey());
+    public ResponseEntity<String> signup(@Valid @RequestBody AdminSignupReqDto reqDto) {
+        adminService.signup(reqDto.getLoginId(), reqDto.getPassword(), reqDto.getNickname(), reqDto.getSecretKey());
+        return ResponseEntity.ok().body("회원가입에 성공하였습니다.");
     }
 
     @PostMapping("/login")
-    public void login(@RequestBody AdminLoginReqDto reqDto, HttpServletResponse response) {
+    public ResponseEntity<String> login(@Valid @RequestBody AdminLoginReqDto reqDto, HttpServletResponse response) {
         TokenInfo tokenInfo = adminService.login(reqDto.getLoginId(), reqDto.getPassword());
         TokenUtil.addHeader(response, tokenInfo.getAccessToken());
         TokenUtil.updateCookie(response, tokenInfo.getRefreshToken(), tokenProperty.getREFRESH_EXPIRE());
+        return ResponseEntity.ok().body("로그인에 성공하였습니다.");
     }
 
     @GetMapping("/test")
@@ -50,7 +55,7 @@ public class AdminController {
     }
 
     @PatchMapping("/warning/{userUUID}")
-    public ResponseEntity<String> warning(@PathVariable String userUUID) {
+    public ResponseEntity<String> warning(@NotBlank @PathVariable String userUUID) {
         adminService.warning(userUUID);
         return ResponseEntity.ok().body("해당 회원이 경고되었습니다.");
     }
@@ -64,14 +69,14 @@ public class AdminController {
     }
 
     @GetMapping("/vip/requestDetail/{vipInfoUUID}")
-    public ResponseEntity<AllVipInfosDto> getVipInfoDetail(@PathVariable("vipInfoUUID") String vipInfoUUID, HttpServletRequest request) {
+    public ResponseEntity<AllVipInfosDto> getVipInfoDetail(@NotBlank @PathVariable("vipInfoUUID") String vipInfoUUID, HttpServletRequest request) {
         AllVipInfosDto vipInfoDetail = adminService.getVipInfoDetail(vipInfoUUID);
         return ResponseEntity.ok().body(vipInfoDetail);
     }
 
     @PatchMapping("/vip/changeState/{vipInfoUUID}")
     public ResponseEntity<String> vipInfoChange(
-            @PathVariable("vipInfoUUID") String vipInfoUUID,
+            @NotBlank @PathVariable("vipInfoUUID") String vipInfoUUID,
             @RequestParam String vipInfoState
     ) {
         adminService.vipInfoChange(vipInfoUUID, vipInfoState);

--- a/src/main/java/shootingstar/var/controller/AdminController.java
+++ b/src/main/java/shootingstar/var/controller/AdminController.java
@@ -1,5 +1,11 @@
 package shootingstar.var.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -15,10 +21,12 @@ import shootingstar.var.Service.AdminService;
 import shootingstar.var.dto.req.AdminLoginReqDto;
 import shootingstar.var.dto.req.AdminSignupReqDto;
 import shootingstar.var.dto.res.*;
+import shootingstar.var.exception.ErrorResponse;
 import shootingstar.var.jwt.TokenInfo;
 import shootingstar.var.jwt.TokenProperty;
 import shootingstar.var.util.TokenUtil;
 
+@Tag(name = "AdminController", description = "관리자 컨트롤러")
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -27,12 +35,43 @@ public class AdminController {
     private final AdminService adminService;
     private final TokenProperty tokenProperty;
 
+    @Operation(summary = "관리자 회원가입 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 회원가입 성공", content = {
+                    @Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))}),
+            @ApiResponse(responseCode = "400",
+                    description =
+                                    "- 잘못된 형식의 관리자 ID : 9001\n" +
+                                    "- 잘못된 형식의 관리자 비밀번호 : 9002\n" +
+                                    "- 잘못된 형식의 관리자 닉네임 : 9003\n" +
+                                    "- 잘못된 형식의 관리자 비밀 키 : 9004",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "409",
+                    description =
+                                    "- 사용할 수 없는 관리자 ID : 9301\n" +
+                                    "- 사용할 수 없는 관리자 닉네임 : 9302\n" +
+                                    "- 잘못된 값의 관리자 비밀 키 : 9303",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody AdminSignupReqDto reqDto) {
         adminService.signup(reqDto.getAdminLoginId(), reqDto.getAdminPassword(), reqDto.getAdminNickname(), reqDto.getAdminSecretKey());
         return ResponseEntity.ok().body("회원가입에 성공하였습니다.");
     }
 
+    @Operation(summary = "관리자 로그인 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 로그인 성공", content = {
+                    @Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))}),
+            @ApiResponse(responseCode = "400",
+                    description =
+                                    "- 잘못된 형식의 관리자 ID : 9001\n" +
+                                    "- 잘못된 형식의 관리자 비밀번호 : 9002",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "403",
+                    description = "로그인 실패 : 잘못된 관리자 아이디 혹은 패스워드",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
     @PostMapping("/login")
     public ResponseEntity<String> login(@Valid @RequestBody AdminLoginReqDto reqDto, HttpServletResponse response) {
         TokenInfo tokenInfo = adminService.login(reqDto.getAdminLoginId(), reqDto.getAdminPassword());

--- a/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 public class AdminLoginReqDto {
     @NotBlank
-    private String loginId;
+    private String adminLoginId;
     @NotBlank
-    private String password;
+    private String adminPassword;
 }

--- a/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminLoginReqDto.java
@@ -1,9 +1,12 @@
 package shootingstar.var.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class AdminLoginReqDto {
+    @NotBlank
     private String loginId;
+    @NotBlank
     private String password;
 }

--- a/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
@@ -1,10 +1,16 @@
 package shootingstar.var.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class AdminSignupReqDto {
+    @NotBlank
     private String loginId;
+    @NotBlank
     private String password;
+    @NotBlank
+    private String nickname;
+    @NotBlank
     private String secretKey;
 }

--- a/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AdminSignupReqDto.java
@@ -6,11 +6,11 @@ import lombok.Data;
 @Data
 public class AdminSignupReqDto {
     @NotBlank
-    private String loginId;
+    private String adminLoginId;
     @NotBlank
-    private String password;
+    private String adminPassword;
     @NotBlank
-    private String nickname;
+    private String adminNickname;
     @NotBlank
-    private String secretKey;
+    private String adminSecretKey;
 }

--- a/src/main/java/shootingstar/var/entity/Admin.java
+++ b/src/main/java/shootingstar/var/entity/Admin.java
@@ -26,13 +26,16 @@ public class Admin extends BaseTimeEntity implements UserDetails {
     private String adminLoginId;
     @NotBlank
     private String password;
+    @NotBlank
+    private String nickname;
     @Enumerated(EnumType.STRING)
     private UserType role;
 
-    public Admin(String adminLoginId, String password) {
+    public Admin(String adminLoginId, String password, String nickname) {
         this.adminUUID = UUID.randomUUID().toString();
         this.adminLoginId = adminLoginId;
         this.password = password;
+        this.nickname = nickname;
         this.role = UserType.ROLE_ADMIN;
     }
 

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -109,8 +109,8 @@ public enum ErrorCode {
     ADMIN_LOGIN_FAILED(FORBIDDEN, "9101", "잘못된 관라자 아이디 혹은 패스워드입니다."),
 
     DUPLICATE_ADMIN_ID(CONFLICT, "9301", "해당 관리자 아이디는 사용할 수 없습니다."),
-    DUPLICATE_ADMIN_NICKNAME(CONFLICT, "9301", "해당 관리자 닉네임은 사용할 수 없습니다."),
-    INCORRECT_VALUE_ADMIN_SECRET_KEY(CONFLICT, "9302", "잘못된 관리자 비밀 키 입니다."),
+    DUPLICATE_ADMIN_NICKNAME(CONFLICT, "9302", "해당 관리자 닉네임은 사용할 수 없습니다."),
+    INCORRECT_VALUE_ADMIN_SECRET_KEY(CONFLICT, "9303", "잘못된 관리자 비밀 키 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -93,6 +93,7 @@ public enum ErrorCode {
     ALREADY_TICKET_CANCEL_CONFLICT(CONFLICT, "6303", "이미 취소된 식사권입니다."),
     REVIEW_CONFLICT(CONFLICT, "6304", "해당 식사권에 대한 리뷰를 작성한 적이 있습니다."),
 
+    INCORRECT_FORMAT_VIP_INFO_UUID(BAD_REQUEST, "7001", "잘못된 형식의 VIP 정보 고유번호입니다."),
     VIP_INFO_NOT_FOUND(NOT_FOUND,"7200", "존재하지 않는 VIP 정보입니다."),
 
     CHAT_ROOM_ACCESS_DENIED(FORBIDDEN, "8100", "접근 권한이 없습니다."),

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -100,6 +100,17 @@ public enum ErrorCode {
     CHAT_MESSAGE_ACCESS_DENIED(FORBIDDEN, "8101", "접근 권한이 없습니다."),
 
     CHAT_ROOM_NOT_FOUND(NOT_FOUND, "8200", "존재하지 않는 채팅방입니다."),
+
+    INCORRECT_FORMAT_ADMIN_ID(BAD_REQUEST, "9001", "잘못된 형식의 관리자 ID입니다."),
+    INCORRECT_FORMAT_ADMIN_PASSWORD(BAD_REQUEST, "9002", "잘못된 형식의 관리자 비밀번호 입니다."),
+    INCORRECT_FORMAT_ADMIN_NICKNAME(BAD_REQUEST, "9003", "잘못된 형식의 관리자 닉네임입니다."),
+    INCORRECT_FORMAT_ADMIN_SECRET_KEY(BAD_REQUEST, "9004", "잘못된 형식의 관리자 비밀 키 입니다."),
+
+    ADMIN_LOGIN_FAILED(FORBIDDEN, "9101", "잘못된 관라자 아이디 혹은 패스워드입니다."),
+
+    DUPLICATE_ADMIN_ID(CONFLICT, "9301", "해당 관리자 아이디는 사용할 수 없습니다."),
+    DUPLICATE_ADMIN_NICKNAME(CONFLICT, "9301", "해당 관리자 닉네임은 사용할 수 없습니다."),
+    INCORRECT_VALUE_ADMIN_SECRET_KEY(CONFLICT, "9302", "잘못된 관리자 비밀 키 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
+++ b/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
@@ -76,6 +76,18 @@ public class GlobalExceptionHandler {
                 } case "ticketReportEvidenceUrl" -> {
                     errorCode = INCORRECT_FORMAT_TICKET_REPORT_EVIDENCE_URL;
                     break;
+                }  case "adminLoginId" -> {
+                    errorCode = INCORRECT_FORMAT_ADMIN_ID;
+                    break;
+                } case "adminPassword" -> {
+                    errorCode = INCORRECT_FORMAT_ADMIN_PASSWORD;
+                    break;
+                } case "adminNickname" -> {
+                    errorCode = INCORRECT_FORMAT_ADMIN_NICKNAME;
+                    break;
+                } case "adminSecretKey" -> {
+                    errorCode = INCORRECT_FORMAT_ADMIN_SECRET_KEY;
+                    break;
                 }
             }
 

--- a/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
+++ b/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
@@ -107,10 +107,12 @@ public class GlobalExceptionHandler {
                 errorCode = INCORRECT_FORMAT_NICKNAME;
             } else if (fieldName.contains("email")) {
                 errorCode = INCORRECT_FORMAT_EMAIL;
-            } else if (fieldName.contains("vipUUID")) {
+            } else if (fieldName.contains("vipUUID") || fieldName.contains("userUUID")) {
                 errorCode = INCORRECT_FORMAT_USER_UUID;
             } else if (fieldName.contains("auctionUUID")) {
                 errorCode = INCORRECT_FORMAT_AUCTION_UUID;
+            } else if (fieldName.contains("vipInfoUUID")) {
+                errorCode = INCORRECT_FORMAT_VIP_INFO_UUID;
             }
 
             if (!errorCode.equals(INCORRECT_FORMAT)) {

--- a/src/main/java/shootingstar/var/repository/admin/AdminRepository.java
+++ b/src/main/java/shootingstar/var/repository/admin/AdminRepository.java
@@ -10,4 +10,6 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
     Optional<Admin> findByAdminUUID(String uuid);
 
     boolean existsByAdminLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
## 관리자 컨트롤러를 수정했습니다.

### api URL 수정
- /api/admin -> /api/lookAtMe로 수정하였습니다.
- Security Config를 수정하였습니다.

### Controller
- warning, getVipFinfoDetail, vipInfoChange 의 pathVariale에 대한 검증을 추가하였습니다.
- signup, login에 대한 반환 값을 수정하였습니다.

### Dto
- AdminSignupReqDto에 nicknmae 필드를 추가하였습니다.
- AdminSignupReqDto, AdminLoginReqDto 에 검증 어노테이션을 추가하였습니다.
- 관리자 에러를 구분하기 위해 관리자 회원가입, 관리자 로그인 dto의 필드명을 수정하였습니다.

### Service
- AdminService signup 메서드에 중복 검증에 대한 로직을 추가하였습니다.

### Repo
- AdminRepo 에 닉네임 중복 검증에 대한 로직을 추가하였습니다.

### Entity
- Admin Entity에 nickname 필드를 추가하였습니다.

### Error
- ErrorCode 에 vipInfoUUID에 대한 에러를 추가하였습니다.
- 관리자 로그인과 회원가입 에러를 정의했습니다.
- ErrorCode에 Admin 에러 코드를 추가하였습니다.
- ExceptionHandler에 관련 에러를 정의하였습니다.

### Swagger
- 관리자 로그인, 관리자 회원가입에 Swagger 설명을 추가하였습니다.