### PR TITLE
Feat: 경매 신고 API

### DIFF
--- a/src/main/java/shootingstar/var/Service/AllUserService.java
+++ b/src/main/java/shootingstar/var/Service/AllUserService.java
@@ -8,11 +8,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shootingstar.var.dto.req.UserSignupReqDto;
 import shootingstar.var.dto.res.*;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.User;
 import shootingstar.var.entity.Wallet;
 import shootingstar.var.enums.type.AuctionSortType;
-import shootingstar.var.enums.type.AuctionType;
 import shootingstar.var.enums.type.UserType;
 import shootingstar.var.exception.CustomException;
 import shootingstar.var.exception.ErrorCode;
@@ -25,7 +24,6 @@ import shootingstar.var.util.MailRedisUtil;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/shootingstar/var/Service/BidService.java
+++ b/src/main/java/shootingstar/var/Service/BidService.java
@@ -1,7 +1,6 @@
 package shootingstar.var.Service;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -15,7 +14,7 @@ import shootingstar.var.dto.req.BidReqDto;
 import shootingstar.var.dto.res.BidInfoResDto;
 import shootingstar.var.dto.res.BidLog;
 import shootingstar.var.dto.res.BidResDto;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.Bid;
 import shootingstar.var.entity.log.PointLog;
 import shootingstar.var.entity.User;

--- a/src/main/java/shootingstar/var/Service/SchedulerService.java
+++ b/src/main/java/shootingstar/var/Service/SchedulerService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.log.DonationLog;
 import shootingstar.var.entity.log.PointLog;
 import shootingstar.var.entity.Wallet;

--- a/src/main/java/shootingstar/var/Service/TicketService.java
+++ b/src/main/java/shootingstar/var/Service/TicketService.java
@@ -12,7 +12,7 @@ import shootingstar.var.dto.req.MeetingTimeSaveReqDto;
 import shootingstar.var.dto.req.ReviewSaveReqDto;
 import shootingstar.var.dto.req.TicketReportReqDto;
 import shootingstar.var.dto.res.DetailTicketResDto;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.log.PointLog;
 import shootingstar.var.entity.Review;
 import shootingstar.var.entity.ticket.Ticket;

--- a/src/main/java/shootingstar/var/Service/VipUserService.java
+++ b/src/main/java/shootingstar/var/Service/VipUserService.java
@@ -10,7 +10,6 @@ import shootingstar.var.dto.res.UserAuctionInvalidityResDto;
 import shootingstar.var.dto.res.UserAuctionParticipateResDto;
 import shootingstar.var.dto.res.UserAuctionSuccessResDto;
 import shootingstar.var.dto.res.VipInfoDto;
-import shootingstar.var.entity.Auction;
 import shootingstar.var.entity.User;
 import shootingstar.var.entity.VipInfo;
 import shootingstar.var.exception.CustomException;

--- a/src/main/java/shootingstar/var/config/SecurityConfig.java
+++ b/src/main/java/shootingstar/var/config/SecurityConfig.java
@@ -67,7 +67,8 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         "/api/ticket/**",
                                         "/api/chat/**",
-                                        "/api/bid/**"
+                                        "/api/bid/**",
+                                        "/api/auction/report"
                                 ).hasAnyRole("BASIC", "VIP")
 
                                 .requestMatchers( // 권한 확인

--- a/src/main/java/shootingstar/var/dto/req/AuctionReportReqDto.java
+++ b/src/main/java/shootingstar/var/dto/req/AuctionReportReqDto.java
@@ -1,0 +1,13 @@
+package shootingstar.var.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class AuctionReportReqDto {
+    @NotBlank
+    private String auctionUUID;
+
+    @NotBlank
+    private String auctionReportContent;
+}

--- a/src/main/java/shootingstar/var/entity/Bid.java
+++ b/src/main/java/shootingstar/var/entity/Bid.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shootingstar.var.entity.auction.Auction;
 
 @Entity
 @Getter

--- a/src/main/java/shootingstar/var/entity/User.java
+++ b/src/main/java/shootingstar/var/entity/User.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.ticket.Ticket;
 import shootingstar.var.enums.type.UserType;
 

--- a/src/main/java/shootingstar/var/entity/auction/Auction.java
+++ b/src/main/java/shootingstar/var/entity/auction/Auction.java
@@ -1,4 +1,4 @@
-package shootingstar.var.entity;
+package shootingstar.var.entity.auction;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import shootingstar.var.entity.BaseTimeEntity;
+import shootingstar.var.entity.Bid;
+import shootingstar.var.entity.User;
 import shootingstar.var.enums.type.AuctionType;
 
 @Entity

--- a/src/main/java/shootingstar/var/entity/auction/AuctionReport.java
+++ b/src/main/java/shootingstar/var/entity/auction/AuctionReport.java
@@ -1,0 +1,50 @@
+package shootingstar.var.entity.auction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shootingstar.var.entity.BaseTimeEntity;
+import shootingstar.var.enums.status.AuctionReportStatus;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class AuctionReport extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long auctionReportId;
+
+    private String auctionReportUUID;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id")
+    private Auction auction;
+
+    private String auctionReportNickname;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String auctionReportContent;
+
+    @Enumerated(EnumType.STRING)
+    private AuctionReportStatus auctionReportStatus;
+
+    @Builder
+    public AuctionReport(Auction auction, String auctionReportNickname, String auctionReportContent) {
+        this.auctionReportUUID = UUID.randomUUID().toString();
+        this.auction = auction;
+        this.auctionReportNickname = auctionReportNickname;
+        this.auctionReportContent = auctionReportContent;
+        this.auctionReportStatus = AuctionReportStatus.STANDBY;
+    }
+}

--- a/src/main/java/shootingstar/var/entity/ticket/Ticket.java
+++ b/src/main/java/shootingstar/var/entity/ticket/Ticket.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.BaseTimeEntity;
 import shootingstar.var.entity.Review;
 import shootingstar.var.entity.User;

--- a/src/main/java/shootingstar/var/enums/status/AuctionReportStatus.java
+++ b/src/main/java/shootingstar/var/enums/status/AuctionReportStatus.java
@@ -1,0 +1,5 @@
+package shootingstar.var.enums.status;
+
+public enum AuctionReportStatus {
+    REFUSAL, STANDBY, APPROVE
+}

--- a/src/main/java/shootingstar/var/exception/ErrorCode.java
+++ b/src/main/java/shootingstar/var/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     INCORRECT_FORMAT_MEETING_PROMISE_TEXT(BAD_REQUEST, "2005", "잘못된 형식의 만남에 대한 약속입니다."),
     INCORRECT_FORMAT_AUCTION_UUID(BAD_REQUEST, "2006", "잘못된 형식의 경매 고유번호입니다."),
     INCORRECT_FORMAT_PRICE(BAD_REQUEST, "2007", "잘못된 형식의 입찰 금액입니다."),
+    INCORRECT_FORMAT_AUCTION_REPORT_CONTENT(BAD_REQUEST, "2008", "잘못된 형식의 경매 신고 내용입니다."),
 
     AUCTION_ACCESS_DENIED(FORBIDDEN, "2100", "접근 권한이 없습니다."),
     AUCTION_NOT_FOUND(NOT_FOUND, "2200", "존재하지 않는 경매입니다."),

--- a/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
+++ b/src/main/java/shootingstar/var/handler/GlobalExceptionHandler.java
@@ -94,6 +94,12 @@ public class GlobalExceptionHandler {
                 } case "adminSecretKey" -> {
                     errorCode = INCORRECT_FORMAT_ADMIN_SECRET_KEY;
                     break;
+                } case "auctionUUID" -> {
+                    errorCode = INCORRECT_FORMAT_AUCTION_UUID;
+                    break;
+                } case "auctionReportContent" -> {
+                    errorCode = INCORRECT_FORMAT_AUCTION_REPORT_CONTENT;
+                    break;
                 }
             }
 

--- a/src/main/java/shootingstar/var/repository/AuctionReportRepository.java
+++ b/src/main/java/shootingstar/var/repository/AuctionReportRepository.java
@@ -1,0 +1,7 @@
+package shootingstar.var.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shootingstar.var.entity.auction.AuctionReport;
+
+public interface AuctionReportRepository extends JpaRepository<AuctionReport, Long> {
+}

--- a/src/main/java/shootingstar/var/repository/AuctionRepository.java
+++ b/src/main/java/shootingstar/var/repository/AuctionRepository.java
@@ -4,7 +4,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 
 import java.util.Optional;
 

--- a/src/main/java/shootingstar/var/repository/AuctionRepositoryImpl.java
+++ b/src/main/java/shootingstar/var/repository/AuctionRepositoryImpl.java
@@ -3,7 +3,6 @@ package shootingstar.var.repository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -15,13 +14,11 @@ import shootingstar.var.dto.res.*;
 import shootingstar.var.enums.type.AuctionSortType;
 import shootingstar.var.enums.type.AuctionType;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.querydsl.core.types.dsl.DateTimePath.*;
-import static shootingstar.var.entity.QAuction.auction;
 import static shootingstar.var.entity.QUser.user;
+import static shootingstar.var.entity.auction.QAuction.auction;
 
 public class AuctionRepositoryImpl implements AuctionRepositoryCustom{
     private final JPAQueryFactory queryFactory;

--- a/src/main/java/shootingstar/var/repository/user/UserRepositoryCustomImpl.java
+++ b/src/main/java/shootingstar/var/repository/user/UserRepositoryCustomImpl.java
@@ -16,11 +16,11 @@ import shootingstar.var.enums.type.UserType;
 import java.util.List;
 
 import static org.springframework.util.StringUtils.hasText;
-import static shootingstar.var.entity.QAuction.auction;
 import static shootingstar.var.entity.QFollow.follow;
 import static shootingstar.var.entity.QReview.review;
 import static shootingstar.var.entity.QUser.user;
 import static shootingstar.var.entity.QVipInfo.vipInfo;
+import static shootingstar.var.entity.auction.QAuction.auction;
 
 public class UserRepositoryCustomImpl implements UserRepositoryCustom{
 

--- a/src/test/java/shootingstar/var/Service/AllUserServiceTest.java
+++ b/src/test/java/shootingstar/var/Service/AllUserServiceTest.java
@@ -14,6 +14,7 @@ import shootingstar.var.dto.res.GetBannerResDto;
 import shootingstar.var.dto.res.ProgressAuctionResDto;
 import shootingstar.var.dto.res.VipDetailResDto;
 import shootingstar.var.entity.*;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.ticket.Ticket;
 import shootingstar.var.enums.type.AuctionSortType;
 import shootingstar.var.enums.type.AuctionType;

--- a/src/test/java/shootingstar/var/Service/AuctionServiceTest.java
+++ b/src/test/java/shootingstar/var/Service/AuctionServiceTest.java
@@ -23,7 +23,7 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import shootingstar.var.dto.req.AuctionCreateReqDto;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.ScheduledTask;
 import shootingstar.var.entity.User;
 import shootingstar.var.entity.log.PointLog;

--- a/src/test/java/shootingstar/var/Service/VipUserServiceTest.java
+++ b/src/test/java/shootingstar/var/Service/VipUserServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import shootingstar.var.dto.req.VipInfoEditResDto;
 import shootingstar.var.dto.res.UserAuctionSuccessResDto;
 import shootingstar.var.dto.res.VipInfoDto;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.User;
 import shootingstar.var.entity.VipApprovalType;
 import shootingstar.var.entity.VipInfo;

--- a/src/test/java/shootingstar/var/util/ParticipatingAuctionRedisUtilTest.java
+++ b/src/test/java/shootingstar/var/util/ParticipatingAuctionRedisUtilTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import shootingstar.var.entity.Auction;
+import shootingstar.var.entity.auction.Auction;
 import shootingstar.var.entity.User;
 import shootingstar.var.enums.type.UserType;
 import shootingstar.var.repository.AuctionRepository;
@@ -14,8 +14,6 @@ import shootingstar.var.repository.user.UserRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class ParticipatingAuctionRedisUtilTest {


### PR DESCRIPTION
### **경매 신고 로직**
- 경매 조회 후 존재하지 않으면 에러 처리
- 경매 타입이 진행중인지 확인 후 에러 처리
- 로그인 한 사용자 조회 후 존재하지 않으면 에러 처리 => 사용자 닉네임을 받아오기 위해
- 경매 신고 데이터 저장

### **고민할 부분**
- 경매가 신고되었을 때 관리자의 승인 처리가 늦어질 시 스케줄링으로 인해 경매가 낙찰되고 식사권이 자동으로 생성될 수 있음 => 이 부분을 어떻게 처리해야 할 지 월요일에 회의가 필요합니다!