### PR TITLE
Refactor : deploy yml 에서 ssl 키 불러오기 구문 삭제

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.CICD_SECRET_KEY }}
       - name: Download config files from S3
         run: |
-          aws s3 cp s3://$AWS_S3_BUCKET/ssl/keystore.p12 src/main/resources/ssl/keystore.p12
           aws s3 cp s3://$AWS_S3_BUCKET/yml/application-database.yml src/main/resources/application-database.yml
           aws s3 cp s3://$AWS_S3_BUCKET/yml/application-iamport.yml src/main/resources/application-iamport.yml
           aws s3 cp s3://$AWS_S3_BUCKET/yml/application-jwt.yml src/main/resources/application-jwt.yml


### PR DESCRIPTION
github action step 중 Download config files from S3 에서 ssl 키 파일 부분을 제거하였습니다.
ssl은 nginx 단에서 처리되도록 변경하였기에 필요없는 동작입니다.