### PR TITLE
Fix : 사용자에 대한 받은 리뷰 조회, 쓴 리뷰 조회에서 NPE 발쌩 수정

### DIFF
--- a/src/main/java/shootingstar/var/entity/Review.java
+++ b/src/main/java/shootingstar/var/entity/Review.java
@@ -1,5 +1,6 @@
 package shootingstar.var.entity;
 
+import com.querydsl.core.annotations.QueryInit;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -31,6 +32,7 @@ public class Review extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id")
+    @QueryInit("auction.user")
     private Ticket ticket;
 
     @NotBlank


### PR DESCRIPTION
사용자에 대한 받은 리뷰 조회, 쓴 리뷰 조회에서 NPE가 발생하던 문제를 수정했습니다.
해당 쿼리에서 객체그래프가 4개이상 넘어가 NPE가 발생하였습니다.
ex) review.ticket.auction.user

해당 문제를 수정하기 위하여 Review 엔티티의 Ticket에 @QueryInit을 추가하였습니다. 자세한 사항은 아래 링크를 참조 바랍니다.
https://www.sunny-son.space/spring/QueryDsl%EC%9D%98%20NPE%20%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0%20+%20Cross%20Join/